### PR TITLE
fix(v2.1.9): split subscription requests into batches of 20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitmart-api",
-  "version": "2.1.7",
+  "version": "2.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitmart-api",
-      "version": "2.1.7",
+      "version": "2.1.9",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmart-api",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Complete & robust Node.js SDK for BitMart's REST APIs and WebSockets, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/src/WebsocketClient.ts
+++ b/src/WebsocketClient.ts
@@ -298,7 +298,7 @@ export class WebsocketClient extends BaseWebsocketClient<
       case 'futuresPrivateV2':
       case 'futuresPublicV2': {
         // Return a number if there's a limit on the number of sub topics per rq
-        return null;
+        return 20;
       }
       default: {
         throw neverGuard(wsKey, `getWsKeyForTopic(): Unhandled wsKey`);


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->

Fixes error seen when attempting to subscribe to ±90 topics. Requests need to be split into batches of 20 per request.

```typescript
import {
  DefaultLogger,
  LogParams,
  RestClient,
  WebsocketClient,
} from 'bitmart-api';

const restClient = new RestClient();

const customLogger: typeof DefaultLogger = {
  trace: (...params: LogParams): void => {
    console.log('silly', ...params);
  },
  info: (...params: LogParams): void => {
    console.info(params);
  },
  error: (...params: LogParams): void => {
    console.error(params);
  },
};

const client = new WebsocketClient(undefined, customLogger);

client.on('open', (data) => {
  console.log('connected ', data?.wsKey);
});

client.on('response', (data) => {
  console.info('response: ', data);
});

const tickers = await restClient.getSpotTickersV3();
const arrSpot = tickers.data.map((i) => `spot/depth20:${i[0]}`);

client.subscribe(arrSpot.slice(0, 90), 'spot');
```

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
