### PR TITLE
feat(): Update endpoints, add trail order and transaction history

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -140,41 +140,43 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 This table includes all endpoints from the official Exchange API docs and corresponding SDK functions for each endpoint that are found in [FuturesClientV2.ts](/src/FuturesClientV2.ts). 
 
-| Function | AUTH | HTTP Method | Endpoint |
-| -------- | :------: | :------: | -------- |
-| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L80) |  | GET | `system/time` |
-| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L84) |  | GET | `system/service` |
-| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L105) |  | GET | `contract/public/details` |
-| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L111) |  | GET | `contract/public/depth` |
-| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L117) |  | GET | `contract/public/open-interest` |
-| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L123) |  | GET | `contract/public/funding-rate` |
-| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L129) |  | GET | `contract/public/kline` |
-| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L141) | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
-| [getFuturesTradeFeeRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L151) | :closed_lock_with_key:  | GET | `contract/private/trade-fee-rate` |
-| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L161) | :closed_lock_with_key:  | GET | `contract/private/order` |
-| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L167) | :closed_lock_with_key:  | GET | `contract/private/order-history` |
-| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L173) | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
-| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L179) | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
-| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L185) | :closed_lock_with_key:  | GET | `contract/private/position` |
-| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L194) | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
-| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L200) | :closed_lock_with_key:  | GET | `contract/private/trades` |
-| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L206) | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
-| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L214) | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
-| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L220) | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
-| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L226) | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
-| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L232) | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
-| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L240) | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
-| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L246) | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
-| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L252) | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
-| [submitFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L258) | :closed_lock_with_key:  | POST | `contract/private/submit-tp-sl-order` |
-| [updateFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L267) | :closed_lock_with_key:  | POST | `contract/private/modify-plan-order` |
-| [updateFuturesPresetPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L275) | :closed_lock_with_key:  | POST | `contract/private/modify-preset-plan-order` |
-| [updateFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L288) | :closed_lock_with_key:  | POST | `contract/private/modify-tp-sl-order` |
+| Function                                                                                                                        | AUTH | HTTP Method | Endpoint |
+|---------------------------------------------------------------------------------------------------------------------------------| :------: | :------: | -------- |
+| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L80)                           |  | GET | `system/time` |
+| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L84)                         |  | GET | `system/service` |
+| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L105)              |  | GET | `contract/public/details` |
+| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L111)                |  | GET | `contract/public/depth` |
+| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L117)                 |  | GET | `contract/public/open-interest` |
+| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L123)                  |  | GET | `contract/public/funding-rate` |
+| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L129)                       |  | GET | `contract/public/kline` |
+| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L141)                | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
+| [getFuturesTradeFeeRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L151)                 | :closed_lock_with_key:  | GET | `contract/private/trade-fee-rate` |
+| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L161)                 | :closed_lock_with_key:  | GET | `contract/private/order` |
+| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L167)          | :closed_lock_with_key:  | GET | `contract/private/order-history` |
+| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L173)            | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
+| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L179)            | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
+| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L185)             | :closed_lock_with_key:  | GET | `contract/private/position` |
+| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L194)                 | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
+| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L200)                | :closed_lock_with_key:  | GET | `contract/private/trades` |
+| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L206)                    | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
+| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L214)                     | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
+| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L220)                     | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
+| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L226)                 | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
+| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L232)                 | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
+| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L240)                 | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
+| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L246)                  | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
+| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L252)                     | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
+| [submitFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L258)                 | :closed_lock_with_key:  | POST | `contract/private/submit-tp-sl-order` |
+| [updateFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L267)                 | :closed_lock_with_key:  | POST | `contract/private/modify-plan-order` |
+| [updateFuturesPresetPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L275)           | :closed_lock_with_key:  | POST | `contract/private/modify-preset-plan-order` |
+| [updateFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L288)                 | :closed_lock_with_key:  | POST | `contract/private/modify-tp-sl-order` |
+| [submitFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L297)                | :closed_lock_with_key:  | POST | `contract/private/submit-trail-order` |
+| [cancelFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L305)                | :closed_lock_with_key:  | POST | `contract/private/cancel-trail-order` |
 | [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L302) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/sub-to-main` |
 | [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L311) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/main-to-sub` |
-| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L320) | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
-| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L329) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
-| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L340) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
-| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L349) | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
-| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L364) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
-| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L370) | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |
+| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L320)       | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
+| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L329)                    | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
+| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L340)                 | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
+| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L349)           | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
+| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L364)             | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
+| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L370)              | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |

--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -158,6 +158,7 @@ This table includes all endpoints from the official Exchange API docs and corres
 | [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L185)             | :closed_lock_with_key:  | GET | `contract/private/position` |
 | [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L194)                 | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
 | [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L200)                | :closed_lock_with_key:  | GET | `contract/private/trades` |
+| [getFuturesAccountTransactionHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L209)    | :closed_lock_with_key:  | GET | `contract/private/transaction-history` |
 | [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L206)                    | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
 | [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L214)                     | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
 | [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L220)                     | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |

--- a/examples/apidoc/FuturesClientV2/cancelFuturesTrailOrder.js
+++ b/examples/apidoc/FuturesClientV2/cancelFuturesTrailOrder.js
@@ -1,0 +1,21 @@
+const { FuturesClientV2 } = require('bitmart-api');
+
+  // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
+  // This bitmart API SDK is available on npm via "npm install bitmart-api"
+  // ENDPOINT: contract/private/cancel-plan-order
+  // METHOD: POST
+  // PUBLIC: NO
+
+const client = new FuturesClientV2({
+  apiKey: 'yourAPIKeyHere',
+  apiSecret: 'yourAPISecretHere',
+  apiMemo: 'yourAPIMemoHere',
+});
+
+client.cancelFuturesTrailOrder(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/FuturesClientV2/getFuturesAccountTransactionHistory.js
+++ b/examples/apidoc/FuturesClientV2/getFuturesAccountTransactionHistory.js
@@ -1,0 +1,21 @@
+const { FuturesClientV2 } = require('bitmart-api');
+
+  // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
+  // This bitmart API SDK is available on npm via "npm install bitmart-api"
+  // ENDPOINT: contract/private/order-history
+  // METHOD: GET
+  // PUBLIC: NO
+
+const client = new FuturesClientV2({
+  apiKey: 'yourAPIKeyHere',
+  apiSecret: 'yourAPISecretHere',
+  apiMemo: 'yourAPIMemoHere',
+});
+
+client.getFuturesAccountTransactionHistory(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/FuturesClientV2/submitFuturesTrailOrder.js
+++ b/examples/apidoc/FuturesClientV2/submitFuturesTrailOrder.js
@@ -1,0 +1,21 @@
+const { FuturesClientV2 } = require('bitmart-api');
+
+  // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
+  // This bitmart API SDK is available on npm via "npm install bitmart-api"
+  // ENDPOINT: contract/private/modify-tp-sl-order
+  // METHOD: POST
+  // PUBLIC: NO
+
+const client = new FuturesClientV2({
+  apiKey: 'yourAPIKeyHere',
+  apiSecret: 'yourAPISecretHere',
+  apiMemo: 'yourAPIMemoHere',
+});
+
+client.submitFuturesTrailOrder(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmart-api",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Complete & robust Node.js SDK for BitMart's REST APIs and WebSockets, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/src/FuturesClientV2.ts
+++ b/src/FuturesClientV2.ts
@@ -8,6 +8,7 @@ import {
 import { RestClientOptions } from './lib/requestUtils.js';
 import {
   FuturesAccountHistoricOrderRequest,
+  FuturesAccountHistoricTransactionRequest,
   FuturesAccountOpenOrdersRequest,
   FuturesAccountOrderRequest,
   FuturesAccountPlanOrdersRequest,
@@ -33,6 +34,7 @@ import {
 import {
   FuturesAccountAsset,
   FuturesAccountHistoricOrder,
+  FuturesAccountHistoricTransaction,
   FuturesAccountOpenOrder,
   FuturesAccountOrder,
   FuturesAccountPlanOrders,
@@ -202,6 +204,12 @@ export class FuturesClientV2 extends BaseRestClient {
     params: FuturesAccountTradesRequest,
   ): Promise<APIResponse<FuturesAccountTrade[]>> {
     return this.getPrivate('contract/private/trades', params);
+  }
+
+  getFuturesAccountTransactionHistory(
+    params: FuturesAccountHistoricTransactionRequest,
+  ): Promise<APIResponse<FuturesAccountHistoricTransaction[]>> {
+    return this.getPrivate('contract/private/transaction-history', params);
   }
 
   getFuturesTransfers(params: FuturesAccountTransfersRequest): Promise<

--- a/src/FuturesClientV2.ts
+++ b/src/FuturesClientV2.ts
@@ -23,6 +23,7 @@ import {
   SubmitFuturesPlanOrderRequest,
   SubmitFuturesSubToMainSubFromSubRequest,
   SubmitFuturesTPSLOrderRequest,
+  SubmitFuturesTrailOrderRequest,
   SubmitFuturesTransferRequest,
   TransferFuturesAssetsRequest,
   UpdateFuturesPlanOrderRequest,
@@ -291,6 +292,20 @@ export class FuturesClientV2 extends BaseRestClient {
     }>
   > {
     return this.postPrivate('contract/private/modify-tp-sl-order', params);
+  }
+
+  submitFuturesTrailOrder(params: SubmitFuturesTrailOrderRequest): Promise<
+    APIResponse<{
+      order_id: number;
+    }>
+  > {
+    return this.postPrivate('contract/private/submit-trail-order', params);
+  }
+
+  cancelFuturesTrailOrder(
+    params: FuturesAccountOrderRequest,
+  ): Promise<APIResponse<any>> {
+    return this.postPrivate('contract/private/cancel-trail-order', params);
   }
 
   /**

--- a/src/types/request/futures.types.ts
+++ b/src/types/request/futures.types.ts
@@ -51,14 +51,11 @@ export interface SubmitFuturesOrderRequest {
   client_order_id?: string;
   side: 1 | 2 | 3 | 4;
   mode?: 1 | 2 | 3 | 4;
-  type?: 'limit' | 'market' | 'trailing';
+  type?: 'limit' | 'market';
   leverage: string;
   open_type: 'cross' | 'isolated';
   size: number;
   price?: string;
-  activation_price?: string;
-  callback_rate?: string;
-  activation_price_type?: 1 | 2;
   preset_take_profit_price_type?: 1 | 2;
   preset_stop_loss_price_type?: 1 | 2;
   preset_take_profit_price?: string;
@@ -181,4 +178,15 @@ export interface UpdateFuturesTPSLOrderRequest {
   price_type: 1 | 2;
   plan_category?: 1 | 2;
   category?: 'limit' | 'market';
+}
+
+export interface SubmitFuturesTrailOrderRequest {
+  symbol: string;
+  side: 1 | 2 | 3 | 4;
+  leverage: string;
+  open_type: 'cross' | 'isolated';
+  size: number;
+  activation_price: string;
+  callback_rate: string;
+  activation_price_type: 1 | 2;
 }

--- a/src/types/request/futures.types.ts
+++ b/src/types/request/futures.types.ts
@@ -37,6 +37,14 @@ export interface FuturesAccountTradesRequest {
   end_time?: number;
 }
 
+export interface FuturesAccountHistoricTransactionRequest {
+  symbol?: string;
+  flow_type?: 0 | 1 | 2 | 3 | 4 | 5;
+  start_time?: number;
+  end_time?: number;
+  page_size?: number;
+}
+
 export interface FuturesAccountTransfersRequest {
   currency?: string;
   time_start?: number;

--- a/src/types/response/futures.types.ts
+++ b/src/types/response/futures.types.ts
@@ -179,6 +179,15 @@ export interface FuturesAccountTrade {
   create_time: number;
 }
 
+export interface FuturesAccountHistoricTransaction {
+  symbol: string;
+  type: string;
+  amount: string;
+  asset: string;
+  time: string;
+  tran_id: string
+}
+
 export interface FuturesAccountTransfer {
   transfer_id: string;
   currency: string;


### PR DESCRIPTION
## Summary
Bitmart API made a new release adding a new endpoint for supporting trailing orders.
And removed the trailing parameters in submit order.

I did the changes to support their new release.

## Additional Information
Feel free to modify my code and do it better, as it's my first PR, not sure if I'm missing something.
