### PR TITLE
feat(v2.1.20): add getFuturesMarketTrade endpoint

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -143,50 +143,51 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L87) |  | GET | `system/time` |
-| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L91) |  | GET | `system/service` |
-| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L112) |  | GET | `contract/public/details` |
-| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L118) |  | GET | `contract/public/depth` |
-| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L124) |  | GET | `contract/public/open-interest` |
-| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L130) |  | GET | `contract/public/funding-rate` |
-| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L136) |  | GET | `contract/public/kline` |
-| [getFuturesMarkPriceKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L142) |  | GET | `contract/public/markprice-kline` |
-| [getFuturesFundingRateHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L148) |  | GET | `contract/public/funding-rate-history` |
-| [getFuturesLeverageBracket()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L164) |  | GET | `contract/public/leverage-bracket` |
-| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L178) | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
-| [getFuturesTradeFeeRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L188) | :closed_lock_with_key:  | GET | `contract/private/trade-fee-rate` |
-| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L198) | :closed_lock_with_key:  | GET | `contract/private/order` |
-| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L204) | :closed_lock_with_key:  | GET | `contract/private/order-history` |
-| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L210) | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
-| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L216) | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
-| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L222) | :closed_lock_with_key:  | GET | `contract/private/position` |
-| [getFuturesAccountPositionsV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L229) | :closed_lock_with_key:  | GET | `contract/private/position` |
-| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L239) | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
-| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L246) | :closed_lock_with_key:  | GET | `contract/private/trades` |
-| [getFuturesAccountTransactionHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L252) | :closed_lock_with_key:  | GET | `contract/private/transaction-history` |
-| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L258) | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
-| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L266) | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
-| [updateFuturesLimitOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L272) | :closed_lock_with_key:  | POST | `contract/private/modify-limit-order` |
-| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L281) | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
-| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L287) | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
-| [cancelAllFuturesOrdersAfter()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L293) | :closed_lock_with_key:  | POST | `contract/private/cancel-all-after` |
-| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L300) | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
-| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L308) | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
-| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L314) | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
-| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L320) | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
-| [submitFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L326) | :closed_lock_with_key:  | POST | `contract/private/submit-tp-sl-order` |
-| [updateFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L335) | :closed_lock_with_key:  | POST | `contract/private/modify-plan-order` |
-| [updateFuturesPresetPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L343) | :closed_lock_with_key:  | POST | `contract/private/modify-preset-plan-order` |
-| [updateFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L356) | :closed_lock_with_key:  | POST | `contract/private/modify-tp-sl-order` |
-| [submitFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L364) | :closed_lock_with_key:  | POST | `contract/private/submit-trail-order` |
-| [cancelFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L372) | :closed_lock_with_key:  | POST | `contract/private/cancel-trail-order` |
-| [setPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L381) | :closed_lock_with_key:  | POST | `contract/private/set-position-mode` |
-| [getPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L390) | :closed_lock_with_key:  | GET | `contract/private/get-position-mode` |
-| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L402) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/sub-to-main` |
-| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L411) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/main-to-sub` |
-| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L420) | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
-| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L429) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
-| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L440) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
-| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L449) | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
-| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L464) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
-| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L470) | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |
+| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L88) |  | GET | `system/time` |
+| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L92) |  | GET | `system/service` |
+| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L113) |  | GET | `contract/public/details` |
+| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L119) |  | GET | `contract/public/depth` |
+| [getFuturesMarketTrade()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L125) |  | GET | `contract/public/market-trade` |
+| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L132) |  | GET | `contract/public/open-interest` |
+| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L138) |  | GET | `contract/public/funding-rate` |
+| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L144) |  | GET | `contract/public/kline` |
+| [getFuturesMarkPriceKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L150) |  | GET | `contract/public/markprice-kline` |
+| [getFuturesFundingRateHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L156) |  | GET | `contract/public/funding-rate-history` |
+| [getFuturesLeverageBracket()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L172) |  | GET | `contract/public/leverage-bracket` |
+| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L186) | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
+| [getFuturesTradeFeeRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L196) | :closed_lock_with_key:  | GET | `contract/private/trade-fee-rate` |
+| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L206) | :closed_lock_with_key:  | GET | `contract/private/order` |
+| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L212) | :closed_lock_with_key:  | GET | `contract/private/order-history` |
+| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L218) | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
+| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L224) | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
+| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L230) | :closed_lock_with_key:  | GET | `contract/private/position` |
+| [getFuturesAccountPositionsV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L237) | :closed_lock_with_key:  | GET | `contract/private/position` |
+| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L247) | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
+| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L254) | :closed_lock_with_key:  | GET | `contract/private/trades` |
+| [getFuturesAccountTransactionHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L260) | :closed_lock_with_key:  | GET | `contract/private/transaction-history` |
+| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L266) | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
+| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L274) | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
+| [updateFuturesLimitOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L280) | :closed_lock_with_key:  | POST | `contract/private/modify-limit-order` |
+| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L289) | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
+| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L295) | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
+| [cancelAllFuturesOrdersAfter()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L301) | :closed_lock_with_key:  | POST | `contract/private/cancel-all-after` |
+| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L308) | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
+| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L316) | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
+| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L322) | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
+| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L328) | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
+| [submitFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L334) | :closed_lock_with_key:  | POST | `contract/private/submit-tp-sl-order` |
+| [updateFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L343) | :closed_lock_with_key:  | POST | `contract/private/modify-plan-order` |
+| [updateFuturesPresetPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L351) | :closed_lock_with_key:  | POST | `contract/private/modify-preset-plan-order` |
+| [updateFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L364) | :closed_lock_with_key:  | POST | `contract/private/modify-tp-sl-order` |
+| [submitFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L372) | :closed_lock_with_key:  | POST | `contract/private/submit-trail-order` |
+| [cancelFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L380) | :closed_lock_with_key:  | POST | `contract/private/cancel-trail-order` |
+| [setPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L389) | :closed_lock_with_key:  | POST | `contract/private/set-position-mode` |
+| [getPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L398) | :closed_lock_with_key:  | GET | `contract/private/get-position-mode` |
+| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L410) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/sub-to-main` |
+| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L419) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/main-to-sub` |
+| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L428) | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
+| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L437) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
+| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L448) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
+| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L457) | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
+| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L472) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
+| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L478) | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |

--- a/examples/apidoc/FuturesClientV2/getFuturesMarketTrade.js
+++ b/examples/apidoc/FuturesClientV2/getFuturesMarketTrade.js
@@ -1,0 +1,21 @@
+const { FuturesClientV2 } = require('bitmart-api');
+
+  // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
+  // This bitmart API SDK is available on npm via "npm install bitmart-api"
+  // ENDPOINT: contract/public/market-trade
+  // METHOD: GET
+  // PUBLIC: YES
+
+const client = new FuturesClientV2({
+  apiKey: 'yourAPIKeyHere',
+  apiSecret: 'yourAPISecretHere',
+  apiMemo: 'yourAPIMemoHere',
+});
+
+client.getFuturesMarketTrade(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitmart-api",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitmart-api",
-      "version": "2.1.19",
+      "version": "2.1.20",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmart-api",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "description": "Complete & robust Node.js SDK for BitMart's REST APIs and WebSockets, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/src/FuturesClientV2.ts
+++ b/src/FuturesClientV2.ts
@@ -51,6 +51,7 @@ import {
   FuturesFundingRateHistory,
   FuturesKline,
   FuturesLeverageBracketRule,
+  FuturesMarketTrade,
   FuturesOpenInterest,
   FuturesOrderSubmitResult,
   FuturesTransferSubmitResult,
@@ -119,6 +120,13 @@ export class FuturesClientV2 extends BaseRestClient {
     symbol: string;
   }): Promise<APIResponse<FuturesContractDepth>> {
     return this.get('contract/public/depth', params);
+  }
+
+  getFuturesMarketTrade(params: {
+    symbol: string;
+    limit?: number; // Default 50; max 100
+  }): Promise<APIResponse<FuturesMarketTrade[]>> {
+    return this.get('contract/public/market-trade', params);
   }
 
   getFuturesOpenInterest(params: {

--- a/src/types/response/futures.types.ts
+++ b/src/types/response/futures.types.ts
@@ -33,6 +33,15 @@ export interface FuturesContractDetails {
   status: string;
 }
 
+export interface FuturesMarketTrade {
+  symbol: string;
+  price: string;
+  qty: string;
+  quote_qty: string;
+  time: number;
+  is_buyer_maker: boolean;
+}
+
 export interface FuturesContractDepth {
   timestamp: number;
   symbol: string;


### PR DESCRIPTION
- Added new method getFuturesMarketTrade to FuturesClientV2 for fetching market trade data.
- Introduced FuturesMarketTrade type for response structure.
- Added example usage for getFuturesMarketTrade in the documentation.

## Summary
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
