### PR TITLE
feat(v2.1.21):  update API endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitmart-api",
-  "version": "2.1.20",
+  "version": "2.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitmart-api",
-      "version": "2.1.20",
+      "version": "2.1.21",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmart-api",
-  "version": "2.1.20",
+  "version": "2.1.21",
   "description": "Complete & robust Node.js SDK for BitMart's REST APIs and WebSockets, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/src/FuturesClientV2.ts
+++ b/src/FuturesClientV2.ts
@@ -238,7 +238,7 @@ export class FuturesClientV2 extends BaseRestClient {
     symbol?: string;
     account?: string;
   }): Promise<APIResponse<FuturesAccountPositionV2[]>> {
-    return this.getPrivate('contract/private/position', params);
+    return this.getPrivate('contract/private/position-v2', params);
   }
 
   /**

--- a/src/types/request/spot.types.ts
+++ b/src/types/request/spot.types.ts
@@ -46,6 +46,7 @@ export interface SubmitSpotOrderV2Request {
   symbol: string;
   side: 'buy' | 'sell';
   type: 'limit' | 'market' | 'limit_maker' | 'ioc';
+  stpmode?: 'none' | 'cancel_maker' | 'cancel_taker' | 'cancel_both';
   client_order_id?: string;
   size?: string;
   price?: string;
@@ -66,6 +67,7 @@ export interface SubmitSpotBatchOrdersV4Request {
     price?: string;
     side: 'buy' | 'sell';
     type: 'limit' | 'market' | 'limit_maker' | 'ioc';
+    stpmode?: 'none' | 'cancel_maker' | 'cancel_taker' | 'cancel_both';
     notional?: string;
   }[];
   recvWindow?: number;

--- a/src/types/response/futures.types.ts
+++ b/src/types/response/futures.types.ts
@@ -133,7 +133,14 @@ export interface FuturesAccountOrder extends FuturesOrderBase {
 
 export interface FuturesAccountHistoricOrder extends FuturesOrderBase {
   price: string;
-  type: 'limit' | 'market' | 'liquidate' | 'bankruptcy' | 'adl' | 'trailing';
+  type:
+    | 'limit'
+    | 'market'
+    | 'liquidate'
+    | 'bankruptcy'
+    | 'adl'
+    | 'trailing'
+    | 'planorder';
   deal_avg_price: string;
   deal_size: string;
   activation_price?: string;
@@ -205,6 +212,7 @@ export interface FuturesAccountPositionV2 {
   open_avg_price: string;
   entry_price: string;
   current_amount: string;
+  position_amount: string;
   realized_value: string;
   mark_value: string;
   account: string;

--- a/src/types/response/spot.types.ts
+++ b/src/types/response/spot.types.ts
@@ -297,6 +297,7 @@ export interface SpotOrderV4 extends SpotTradeBase {
   priceAvg: string;
   filledSize: string;
   filledNotional: string;
+  stpmode: 'none' | 'cancel_maker' | 'cancel_taker' | 'cancel_both';
 }
 
 export interface CancelSpotBatchOrdersV4Response {
@@ -314,6 +315,7 @@ export interface SpotAccountTradeV4 extends SpotTradeBase {
   tradeRole: 'taker' | 'maker';
   orderMode: 'spot' | 'iso_margin';
   type: 'limit' | 'market' | 'limit_maker' | 'ioc';
+  stpmode: 'none' | 'cancel_maker' | 'cancel_taker' | 'cancel_both';
 }
 
 /**


### PR DESCRIPTION
- Updated package version in package.json and package-lock.json to 2.1.21.
- Updated the endpoint in FuturesClientV2 from 'contract/private/position' to 'contract/private/position-v2'.
- Added optional 'stpmode' field to SubmitSpotOrderV2Request and SubmitSpotBatchOrdersV4Request interfaces.
- Expanded FuturesAccountHistoricOrder type to include 'planorder' as a valid order type.
- Added 'position_amount' field to FuturesAccountPositionV2 interface.
- Included 'stpmode' field in SpotOrderV4 and SpotAccountTradeV4 interfaces.

## Summary
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
