### PR TITLE
feat(v2.4.1): add new Spot algo order endpoints and update FuturesClientV2 with additional request types

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -49,93 +49,100 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L201) |  | GET | `system/time` |
-| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L205) |  | GET | `system/service` |
-| [getSpotCurrenciesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L215) |  | GET | `spot/v1/currencies` |
-| [getSpotTradingPairsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L221) |  | GET | `spot/v1/symbols` |
-| [getSpotTradingPairDetailsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L225) |  | GET | `spot/v1/symbols/details` |
-| [getSpotTickersV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L231) |  | GET | `spot/quotation/v3/tickers` |
-| [getSpotTickerV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L235) |  | GET | `spot/quotation/v3/ticker` |
-| [getSpotLatestKlineV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L241) |  | GET | `spot/quotation/v3/lite-klines` |
-| [getSpotHistoryKlineV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L247) |  | GET | `spot/quotation/v3/klines` |
-| [getSpotOrderBookDepthV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L253) |  | GET | `spot/quotation/v3/books` |
-| [getSpotRecentTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L260) |  | GET | `spot/quotation/v3/trades` |
-| [getSpotTickersV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L276) |  | GET | `spot/v2/ticker` |
-| [getSpotTickerV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L283) |  | GET | `spot/v1/ticker_detail` |
-| [getSpotKLineStepsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L292) |  | GET | `spot/v1/steps` |
-| [getSpotKlinesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L299) |  | GET | `spot/v1/symbols/kline` |
-| [getSpotOrderBookDepthV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L308) |  | GET | `spot/v1/symbols/book` |
-| [getAccountBalancesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L320) | :closed_lock_with_key:  | GET | `account/v1/wallet` |
-| [getAccountCurrenciesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L326) |  | GET | `account/v1/currencies` |
-| [getSpotWalletBalanceV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L332) | :closed_lock_with_key:  | GET | `spot/v1/wallet` |
-| [getAccountDepositAddressV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L338) | :closed_lock_with_key:  | GET | `account/v1/deposit/address` |
-| [getAccountWithdrawQuotaV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L344) | :closed_lock_with_key:  | GET | `account/v1/withdraw/charge` |
-| [submitWithdrawalV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L350) | :closed_lock_with_key:  | POST | `account/v1/withdraw/apply` |
-| [getWithdrawAddressList()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L356) | :closed_lock_with_key:  | GET | `account/v1/withdraw/address/list` |
-| [getDepositWithdrawHistoryV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L364) | :closed_lock_with_key:  | GET | `account/v2/deposit-withdraw/history` |
-| [getDepositWithdrawDetailV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L370) | :closed_lock_with_key:  | GET | `account/v1/deposit-withdraw/detail` |
-| [getMarginAccountDetailsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L376) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/account` |
-| [submitMarginAssetTransferV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L382) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/transfer` |
-| [getBasicSpotFeeRateV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L388) | :closed_lock_with_key:  | GET | `spot/v1/user_fee` |
-| [getActualSpotTradeFeeRateV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L392) | :closed_lock_with_key:  | GET | `spot/v1/trade_fee` |
-| [submitSpotOrderV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L404) | :closed_lock_with_key:  | POST | `spot/v2/submit_order` |
-| [submitMarginOrderV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L410) | :closed_lock_with_key:  | POST | `spot/v1/margin/submit_order` |
-| [submitSpotBatchOrdersV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L419) | :closed_lock_with_key:  | POST | `spot/v2/batch_orders` |
-| [cancelSpotOrderV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L425) | :closed_lock_with_key:  | POST | `spot/v3/cancel_order` |
-| [submitSpotBatchOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L431) | :closed_lock_with_key:  | POST | `spot/v4/batch_orders` |
-| [cancelSpotBatchOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L442) | :closed_lock_with_key:  | POST | `spot/v4/cancel_orders` |
-| [cancelAllSpotOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L448) | :closed_lock_with_key:  | POST | `spot/v4/cancel_all` |
-| [cancelSpotOrdersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L458) | :closed_lock_with_key:  | POST | `spot/v1/cancel_orders` |
-| [getSpotOrderByIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L468) | :closed_lock_with_key:  | POST | `spot/v4/query/order` |
-| [getSpotOrderByClientOrderIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L477) | :closed_lock_with_key:  | POST | `spot/v4/query/client-order` |
-| [getSpotOpenOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L483) | :closed_lock_with_key:  | POST | `spot/v4/query/open-orders` |
-| [getSpotHistoricOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L489) | :closed_lock_with_key:  | POST | `spot/v4/query/history-orders` |
-| [getSpotAccountTradesV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L498) | :closed_lock_with_key:  | POST | `spot/v4/query/trades` |
-| [getSpotAccountOrderTradesV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L507) | :closed_lock_with_key:  | POST | `spot/v4/query/order-trades` |
-| [marginBorrowV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L520) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/borrow` |
-| [marginRepayV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L526) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/repay` |
-| [getMarginBorrowRecordV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L532) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/borrow_record` |
-| [getMarginRepayRecordV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L538) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/repay_record` |
-| [getMarginBorrowingRatesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L547) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/pairs` |
-| [submitMainTransferSubToMainV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L562) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/sub-to-main` |
-| [submitSubTransferSubToMainV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L571) | :closed_lock_with_key:  | POST | `account/sub-account/sub/v1/sub-to-main` |
-| [submitMainTransferMainToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L577) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/main-to-sub` |
-| [submitMainTransferSubToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L583) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/sub-to-sub` |
-| [submitSubTransferSubToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L589) | :closed_lock_with_key:  | POST | `account/sub-account/sub/v1/sub-to-sub` |
-| [getSubTransfersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L595) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/transfer-list` |
-| [getAccountSubTransfersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L601) | :closed_lock_with_key:  | GET | `account/sub-account/v1/transfer-history` |
-| [getSubSpotWalletBalancesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L607) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/wallet` |
-| [getSubAccountsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L613) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/subaccount-list` |
-| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L634) |  | GET | `contract/public/details` |
-| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L643) |  | GET | `contract/public/depth` |
-| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L652) |  | GET | `contract/public/open-interest` |
-| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L661) |  | GET | `contract/public/funding-rate` |
-| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L670) |  | GET | `contract/public/kline` |
-| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L685) | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
-| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L698) | :closed_lock_with_key:  | GET | `contract/private/order` |
-| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L707) | :closed_lock_with_key:  | GET | `contract/private/order-history` |
-| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L716) | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
-| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L725) | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
-| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L734) | :closed_lock_with_key:  | GET | `contract/private/position` |
-| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L743) | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
-| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L752) | :closed_lock_with_key:  | GET | `contract/private/trades` |
-| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L761) | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
-| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L772) | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
-| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L780) | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
-| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L789) | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
-| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L798) | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
-| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L809) | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
-| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L818) | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
-| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L827) | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
-| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L842) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/sub-to-main` |
-| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L854) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/main-to-sub` |
-| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L866) | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
-| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L878) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
-| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L892) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
-| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L904) | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
-| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L922) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
-| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L931) | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |
-| [getBrokerRebate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L943) | :closed_lock_with_key:  | GET | `spot/v1/broker/rebate` |
+| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L209) |  | GET | `system/time` |
+| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L213) |  | GET | `system/service` |
+| [getSpotCurrenciesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L223) |  | GET | `spot/v1/currencies` |
+| [getSpotTradingPairsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L229) |  | GET | `spot/v1/symbols` |
+| [getSpotTradingPairDetailsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L233) |  | GET | `spot/v1/symbols/details` |
+| [getSpotTickersV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L239) |  | GET | `spot/quotation/v3/tickers` |
+| [getSpotTickerV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L243) |  | GET | `spot/quotation/v3/ticker` |
+| [getSpotLatestKlineV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L249) |  | GET | `spot/quotation/v3/lite-klines` |
+| [getSpotHistoryKlineV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L255) |  | GET | `spot/quotation/v3/klines` |
+| [getSpotOrderBookDepthV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L261) |  | GET | `spot/quotation/v3/books` |
+| [getSpotRecentTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L268) |  | GET | `spot/quotation/v3/trades` |
+| [getSpotTickersV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L284) |  | GET | `spot/v2/ticker` |
+| [getSpotTickerV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L291) |  | GET | `spot/v1/ticker_detail` |
+| [getSpotKLineStepsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L300) |  | GET | `spot/v1/steps` |
+| [getSpotKlinesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L307) |  | GET | `spot/v1/symbols/kline` |
+| [getSpotOrderBookDepthV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L316) |  | GET | `spot/v1/symbols/book` |
+| [getAccountBalancesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L328) | :closed_lock_with_key:  | GET | `account/v1/wallet` |
+| [getAccountCurrenciesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L334) |  | GET | `account/v1/currencies` |
+| [getSpotWalletBalanceV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L340) | :closed_lock_with_key:  | GET | `spot/v1/wallet` |
+| [getAccountDepositAddressV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L346) | :closed_lock_with_key:  | GET | `account/v1/deposit/address` |
+| [getAccountWithdrawQuotaV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L352) | :closed_lock_with_key:  | GET | `account/v1/withdraw/charge` |
+| [submitWithdrawalV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L358) | :closed_lock_with_key:  | POST | `account/v1/withdraw/apply` |
+| [getWithdrawAddressList()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L364) | :closed_lock_with_key:  | GET | `account/v1/withdraw/address/list` |
+| [getDepositWithdrawHistoryV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L372) | :closed_lock_with_key:  | GET | `account/v2/deposit-withdraw/history` |
+| [getDepositWithdrawDetailV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L378) | :closed_lock_with_key:  | GET | `account/v1/deposit-withdraw/detail` |
+| [getMarginAccountDetailsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L384) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/account` |
+| [submitMarginAssetTransferV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L390) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/transfer` |
+| [getBasicSpotFeeRateV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L396) | :closed_lock_with_key:  | GET | `spot/v1/user_fee` |
+| [getActualSpotTradeFeeRateV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L400) | :closed_lock_with_key:  | GET | `spot/v1/trade_fee` |
+| [submitSpotOrderV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L412) | :closed_lock_with_key:  | POST | `spot/v2/submit_order` |
+| [submitMarginOrderV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L418) | :closed_lock_with_key:  | POST | `spot/v1/margin/submit_order` |
+| [submitSpotBatchOrdersV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L427) | :closed_lock_with_key:  | POST | `spot/v2/batch_orders` |
+| [cancelSpotOrderV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L433) | :closed_lock_with_key:  | POST | `spot/v3/cancel_order` |
+| [submitSpotBatchOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L439) | :closed_lock_with_key:  | POST | `spot/v4/batch_orders` |
+| [cancelSpotBatchOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L450) | :closed_lock_with_key:  | POST | `spot/v4/cancel_orders` |
+| [cancelAllSpotOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L456) | :closed_lock_with_key:  | POST | `spot/v4/cancel_all` |
+| [cancelSpotOrdersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L466) | :closed_lock_with_key:  | POST | `spot/v1/cancel_orders` |
+| [getSpotOrderByIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L476) | :closed_lock_with_key:  | POST | `spot/v4/query/order` |
+| [getSpotOrderByClientOrderIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L485) | :closed_lock_with_key:  | POST | `spot/v4/query/client-order` |
+| [getSpotOpenOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L491) | :closed_lock_with_key:  | POST | `spot/v4/query/open-orders` |
+| [getSpotHistoricOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L497) | :closed_lock_with_key:  | POST | `spot/v4/query/history-orders` |
+| [getSpotAccountTradesV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L506) | :closed_lock_with_key:  | POST | `spot/v4/query/trades` |
+| [getSpotAccountOrderTradesV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L515) | :closed_lock_with_key:  | POST | `spot/v4/query/order-trades` |
+| [submitSpotAlgoOrderV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L522) | :closed_lock_with_key:  | POST | `spot/v4/algo/submit_order` |
+| [cancelSpotAlgoOrderV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L528) | :closed_lock_with_key:  | POST | `spot/v4/algo/cancel_order` |
+| [cancelAllSpotAlgoOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L534) | :closed_lock_with_key:  | POST | `spot/v4/algo/cancel_all` |
+| [getSpotAlgoOrderByIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L540) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/order` |
+| [getSpotAlgoOrderByClientOrderIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L546) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/client-order` |
+| [getSpotAlgoOpenOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L552) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/open-orders` |
+| [getSpotAlgoHistoryOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L558) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/history-orders` |
+| [marginBorrowV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L570) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/borrow` |
+| [marginRepayV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L576) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/repay` |
+| [getMarginBorrowRecordV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L582) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/borrow_record` |
+| [getMarginRepayRecordV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L588) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/repay_record` |
+| [getMarginBorrowingRatesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L597) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/pairs` |
+| [submitMainTransferSubToMainV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L612) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/sub-to-main` |
+| [submitSubTransferSubToMainV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L621) | :closed_lock_with_key:  | POST | `account/sub-account/sub/v1/sub-to-main` |
+| [submitMainTransferMainToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L627) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/main-to-sub` |
+| [submitMainTransferSubToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L633) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/sub-to-sub` |
+| [submitSubTransferSubToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L639) | :closed_lock_with_key:  | POST | `account/sub-account/sub/v1/sub-to-sub` |
+| [getSubTransfersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L645) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/transfer-list` |
+| [getAccountSubTransfersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L651) | :closed_lock_with_key:  | GET | `account/sub-account/v1/transfer-history` |
+| [getSubSpotWalletBalancesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L657) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/wallet` |
+| [getSubAccountsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L663) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/subaccount-list` |
+| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L684) |  | GET | `contract/public/details` |
+| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L693) |  | GET | `contract/public/depth` |
+| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L702) |  | GET | `contract/public/open-interest` |
+| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L711) |  | GET | `contract/public/funding-rate` |
+| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L720) |  | GET | `contract/public/kline` |
+| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L735) | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
+| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L748) | :closed_lock_with_key:  | GET | `contract/private/order` |
+| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L757) | :closed_lock_with_key:  | GET | `contract/private/order-history` |
+| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L766) | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
+| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L775) | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
+| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L784) | :closed_lock_with_key:  | GET | `contract/private/position` |
+| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L793) | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
+| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L802) | :closed_lock_with_key:  | GET | `contract/private/trades` |
+| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L811) | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
+| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L822) | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
+| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L830) | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
+| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L839) | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
+| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L848) | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
+| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L859) | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
+| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L868) | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
+| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L877) | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
+| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L892) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/sub-to-main` |
+| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L904) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/main-to-sub` |
+| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L916) | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
+| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L928) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
+| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L942) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
+| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L954) | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
+| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L972) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
+| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L981) | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |
+| [getBrokerRebate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L993) | :closed_lock_with_key:  | GET | `spot/v1/broker/rebate` |
 
 # FuturesClientV2.ts
 
@@ -143,54 +150,57 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L97) |  | GET | `system/time` |
-| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L101) |  | GET | `system/service` |
-| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L122) |  | GET | `contract/public/details` |
-| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L128) |  | GET | `contract/public/depth` |
-| [getFuturesMarketTrade()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L134) |  | GET | `contract/public/market-trade` |
-| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L141) |  | GET | `contract/public/open-interest` |
-| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L147) |  | GET | `contract/public/funding-rate` |
-| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L153) |  | GET | `contract/public/kline` |
-| [getFuturesMarkPriceKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L159) |  | GET | `contract/public/markprice-kline` |
-| [getFuturesFundingRateHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L165) |  | GET | `contract/public/funding-rate-history` |
-| [getFuturesLeverageBracket()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L181) |  | GET | `contract/public/leverage-bracket` |
-| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L195) | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
-| [getFuturesTradeFeeRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L205) | :closed_lock_with_key:  | GET | `contract/private/trade-fee-rate` |
-| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L215) | :closed_lock_with_key:  | GET | `contract/private/order` |
-| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L221) | :closed_lock_with_key:  | GET | `contract/private/order-history` |
-| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L227) | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
-| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L233) | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
-| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L239) | :closed_lock_with_key:  | GET | `contract/private/position` |
-| [getFuturesAccountPositionsV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L246) | :closed_lock_with_key:  | GET | `contract/private/position-v2` |
-| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L256) | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
-| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L263) | :closed_lock_with_key:  | GET | `contract/private/trades` |
-| [getFuturesAccountTransactionHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L269) | :closed_lock_with_key:  | GET | `contract/private/transaction-history` |
-| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L275) | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
-| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L283) | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
-| [updateFuturesLimitOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L289) | :closed_lock_with_key:  | POST | `contract/private/modify-limit-order` |
-| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L298) | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
-| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L304) | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
-| [cancelAllFuturesOrdersAfter()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L310) | :closed_lock_with_key:  | POST | `contract/private/cancel-all-after` |
-| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L317) | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
-| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L325) | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
-| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L331) | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
-| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L337) | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
-| [submitFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L343) | :closed_lock_with_key:  | POST | `contract/private/submit-tp-sl-order` |
-| [updateFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L352) | :closed_lock_with_key:  | POST | `contract/private/modify-plan-order` |
-| [updateFuturesPresetPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L360) | :closed_lock_with_key:  | POST | `contract/private/modify-preset-plan-order` |
-| [updateFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L373) | :closed_lock_with_key:  | POST | `contract/private/modify-tp-sl-order` |
-| [submitFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L381) | :closed_lock_with_key:  | POST | `contract/private/submit-trail-order` |
-| [cancelFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L389) | :closed_lock_with_key:  | POST | `contract/private/cancel-trail-order` |
-| [setPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L398) | :closed_lock_with_key:  | POST | `contract/private/set-position-mode` |
-| [getPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L407) | :closed_lock_with_key:  | GET | `contract/private/get-position-mode` |
-| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L419) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/sub-to-main` |
-| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L428) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/main-to-sub` |
-| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L437) | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
-| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L446) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
-| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L457) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
-| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L466) | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
-| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L481) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
-| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L487) | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |
-| [getFuturesAffiliateRebateUser()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L498) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-user` |
-| [getFuturesAffiliateRebateApi()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L509) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-api` |
-| [submitFuturesSimulatedClaim()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L531) | :closed_lock_with_key:  | POST | `contract/private/claim` |
+| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L103) |  | GET | `system/time` |
+| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L107) |  | GET | `system/service` |
+| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L128) |  | GET | `contract/public/details` |
+| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L134) |  | GET | `contract/public/depth` |
+| [getFuturesMarketTrade()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L140) |  | GET | `contract/public/market-trade` |
+| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L147) |  | GET | `contract/public/open-interest` |
+| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L153) |  | GET | `contract/public/funding-rate` |
+| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L159) |  | GET | `contract/public/kline` |
+| [getFuturesMarkPriceKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L165) |  | GET | `contract/public/markprice-kline` |
+| [getFuturesFundingRateHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L171) |  | GET | `contract/public/funding-rate-history` |
+| [getFuturesLeverageBracket()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L187) |  | GET | `contract/public/leverage-bracket` |
+| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L201) | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
+| [getFuturesTradeFeeRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L211) | :closed_lock_with_key:  | GET | `contract/private/trade-fee-rate` |
+| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L221) | :closed_lock_with_key:  | GET | `contract/private/order` |
+| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L227) | :closed_lock_with_key:  | GET | `contract/private/order-history` |
+| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L233) | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
+| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L239) | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
+| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L245) | :closed_lock_with_key:  | GET | `contract/private/position` |
+| [getFuturesAccountPositionsV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L252) | :closed_lock_with_key:  | GET | `contract/private/position-v2` |
+| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L262) | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
+| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L269) | :closed_lock_with_key:  | GET | `contract/private/trades` |
+| [getFuturesAccountTransactionHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L275) | :closed_lock_with_key:  | GET | `contract/private/transaction-history` |
+| [getFuturesAutoRepayment()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L284) | :closed_lock_with_key:  | GET | `contract/private/auto_repayment` |
+| [getFuturesCrossCollateralInterestLog()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L293) | :closed_lock_with_key:  | GET | `contract/private/cross_collateral/interest_log` |
+| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L302) | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
+| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L310) | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
+| [updateFuturesLimitOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L316) | :closed_lock_with_key:  | POST | `contract/private/modify-limit-order` |
+| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L325) | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
+| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L331) | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
+| [cancelAllFuturesOrdersAfter()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L337) | :closed_lock_with_key:  | POST | `contract/private/cancel-all-after` |
+| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L344) | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
+| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L352) | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
+| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L358) | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
+| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L364) | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
+| [submitFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L370) | :closed_lock_with_key:  | POST | `contract/private/submit-tp-sl-order` |
+| [updateFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L379) | :closed_lock_with_key:  | POST | `contract/private/modify-plan-order` |
+| [updateFuturesPresetPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L387) | :closed_lock_with_key:  | POST | `contract/private/modify-preset-plan-order` |
+| [updateFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L400) | :closed_lock_with_key:  | POST | `contract/private/modify-tp-sl-order` |
+| [submitFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L408) | :closed_lock_with_key:  | POST | `contract/private/submit-trail-order` |
+| [cancelFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L416) | :closed_lock_with_key:  | POST | `contract/private/cancel-trail-order` |
+| [setPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L425) | :closed_lock_with_key:  | POST | `contract/private/set-position-mode` |
+| [getPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L434) | :closed_lock_with_key:  | GET | `contract/private/get-position-mode` |
+| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L446) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/sub-to-main` |
+| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L455) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/main-to-sub` |
+| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L464) | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
+| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L473) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
+| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L484) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
+| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L493) | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
+| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L508) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
+| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L514) | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |
+| [getFuturesAffiliateRebateUser()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L525) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-inviteUser` |
+| [getFuturesAffiliateRebateApi()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L539) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-api` |
+| [getFuturesAffiliateDepositWithdrawalList()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L549) | :closed_lock_with_key:  | GET | `contract/private/affiliate/deposit-withdrawal-list` |
+| [submitFuturesSimulatedClaim()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L574) | :closed_lock_with_key:  | POST | `contract/private/claim` |

--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -1,4 +1,3 @@
-
 # Endpoint maps
 
 <p align="center">
@@ -10,7 +9,7 @@
   </a>
 </p>
 
-Each REST client is a JavaScript class, which provides functions individually mapped to each endpoint available in the exchange's API offering. 
+Each REST client is a JavaScript class, which provides functions individually mapped to each endpoint available in the exchange's API offering.
 
 The following table shows all methods available in each REST client, whether the method requires authentication (automatically handled if API keys are provided), as well as the exact endpoint each method is connected to.
 
@@ -19,9 +18,9 @@ This can be used to easily find which method to call, once you have [found which
 All REST clients are in the [src](/src) folder. For usage examples, make sure to check the [examples](/examples) folder.
 
 List of clients:
+
 - [RestClient](#RestClientts)
 - [FuturesClientV2](#FuturesClientV2ts)
-
 
 If anything is missing or wrong, please open an issue or let us know in our [Node.js Traders](https://t.me/nodetraders) telegram group!
 
@@ -42,165 +41,165 @@ Table consists of 4 parts:
 
 **Endpoint** is the URL that the function uses to call the endpoint. Best way to find exact function you need for the endpoint is to search for URL in this table and find corresponding function name.
 
-
 # RestClient.ts
 
-This table includes all endpoints from the official Exchange API docs and corresponding SDK functions for each endpoint that are found in [RestClient.ts](/src/RestClient.ts). 
+This table includes all endpoints from the official Exchange API docs and corresponding SDK functions for each endpoint that are found in [RestClient.ts](/src/RestClient.ts).
 
-| Function | AUTH | HTTP Method | Endpoint |
-| -------- | :------: | :------: | -------- |
-| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L209) |  | GET | `system/time` |
-| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L213) |  | GET | `system/service` |
-| [getSpotCurrenciesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L223) |  | GET | `spot/v1/currencies` |
-| [getSpotTradingPairsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L229) |  | GET | `spot/v1/symbols` |
-| [getSpotTradingPairDetailsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L233) |  | GET | `spot/v1/symbols/details` |
-| [getSpotTickersV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L239) |  | GET | `spot/quotation/v3/tickers` |
-| [getSpotTickerV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L243) |  | GET | `spot/quotation/v3/ticker` |
-| [getSpotLatestKlineV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L249) |  | GET | `spot/quotation/v3/lite-klines` |
-| [getSpotHistoryKlineV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L255) |  | GET | `spot/quotation/v3/klines` |
-| [getSpotOrderBookDepthV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L261) |  | GET | `spot/quotation/v3/books` |
-| [getSpotRecentTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L268) |  | GET | `spot/quotation/v3/trades` |
-| [getSpotTickersV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L284) |  | GET | `spot/v2/ticker` |
-| [getSpotTickerV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L291) |  | GET | `spot/v1/ticker_detail` |
-| [getSpotKLineStepsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L300) |  | GET | `spot/v1/steps` |
-| [getSpotKlinesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L307) |  | GET | `spot/v1/symbols/kline` |
-| [getSpotOrderBookDepthV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L316) |  | GET | `spot/v1/symbols/book` |
-| [getAccountBalancesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L328) | :closed_lock_with_key:  | GET | `account/v1/wallet` |
-| [getAccountCurrenciesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L334) |  | GET | `account/v1/currencies` |
-| [getSpotWalletBalanceV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L340) | :closed_lock_with_key:  | GET | `spot/v1/wallet` |
-| [getAccountDepositAddressV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L346) | :closed_lock_with_key:  | GET | `account/v1/deposit/address` |
-| [getAccountWithdrawQuotaV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L352) | :closed_lock_with_key:  | GET | `account/v1/withdraw/charge` |
-| [submitWithdrawalV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L358) | :closed_lock_with_key:  | POST | `account/v1/withdraw/apply` |
-| [getWithdrawAddressList()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L364) | :closed_lock_with_key:  | GET | `account/v1/withdraw/address/list` |
-| [getDepositWithdrawHistoryV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L372) | :closed_lock_with_key:  | GET | `account/v2/deposit-withdraw/history` |
-| [getDepositWithdrawDetailV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L378) | :closed_lock_with_key:  | GET | `account/v1/deposit-withdraw/detail` |
-| [getMarginAccountDetailsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L384) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/account` |
-| [submitMarginAssetTransferV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L390) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/transfer` |
-| [getBasicSpotFeeRateV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L396) | :closed_lock_with_key:  | GET | `spot/v1/user_fee` |
-| [getActualSpotTradeFeeRateV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L400) | :closed_lock_with_key:  | GET | `spot/v1/trade_fee` |
-| [submitSpotOrderV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L412) | :closed_lock_with_key:  | POST | `spot/v2/submit_order` |
-| [submitMarginOrderV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L418) | :closed_lock_with_key:  | POST | `spot/v1/margin/submit_order` |
-| [submitSpotBatchOrdersV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L427) | :closed_lock_with_key:  | POST | `spot/v2/batch_orders` |
-| [cancelSpotOrderV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L433) | :closed_lock_with_key:  | POST | `spot/v3/cancel_order` |
-| [submitSpotBatchOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L439) | :closed_lock_with_key:  | POST | `spot/v4/batch_orders` |
-| [cancelSpotBatchOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L450) | :closed_lock_with_key:  | POST | `spot/v4/cancel_orders` |
-| [cancelAllSpotOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L456) | :closed_lock_with_key:  | POST | `spot/v4/cancel_all` |
-| [cancelSpotOrdersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L466) | :closed_lock_with_key:  | POST | `spot/v1/cancel_orders` |
-| [getSpotOrderByIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L476) | :closed_lock_with_key:  | POST | `spot/v4/query/order` |
-| [getSpotOrderByClientOrderIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L485) | :closed_lock_with_key:  | POST | `spot/v4/query/client-order` |
-| [getSpotOpenOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L491) | :closed_lock_with_key:  | POST | `spot/v4/query/open-orders` |
-| [getSpotHistoricOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L497) | :closed_lock_with_key:  | POST | `spot/v4/query/history-orders` |
-| [getSpotAccountTradesV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L506) | :closed_lock_with_key:  | POST | `spot/v4/query/trades` |
-| [getSpotAccountOrderTradesV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L515) | :closed_lock_with_key:  | POST | `spot/v4/query/order-trades` |
-| [submitSpotAlgoOrderV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L522) | :closed_lock_with_key:  | POST | `spot/v4/algo/submit_order` |
-| [cancelSpotAlgoOrderV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L528) | :closed_lock_with_key:  | POST | `spot/v4/algo/cancel_order` |
-| [cancelAllSpotAlgoOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L534) | :closed_lock_with_key:  | POST | `spot/v4/algo/cancel_all` |
-| [getSpotAlgoOrderByIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L540) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/order` |
-| [getSpotAlgoOrderByClientOrderIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L546) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/client-order` |
-| [getSpotAlgoOpenOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L552) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/open-orders` |
-| [getSpotAlgoHistoryOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L558) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/history-orders` |
-| [marginBorrowV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L570) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/borrow` |
-| [marginRepayV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L576) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/repay` |
-| [getMarginBorrowRecordV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L582) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/borrow_record` |
-| [getMarginRepayRecordV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L588) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/repay_record` |
-| [getMarginBorrowingRatesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L597) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/pairs` |
-| [submitMainTransferSubToMainV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L612) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/sub-to-main` |
-| [submitSubTransferSubToMainV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L621) | :closed_lock_with_key:  | POST | `account/sub-account/sub/v1/sub-to-main` |
-| [submitMainTransferMainToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L627) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/main-to-sub` |
-| [submitMainTransferSubToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L633) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/sub-to-sub` |
-| [submitSubTransferSubToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L639) | :closed_lock_with_key:  | POST | `account/sub-account/sub/v1/sub-to-sub` |
-| [getSubTransfersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L645) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/transfer-list` |
-| [getAccountSubTransfersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L651) | :closed_lock_with_key:  | GET | `account/sub-account/v1/transfer-history` |
-| [getSubSpotWalletBalancesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L657) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/wallet` |
-| [getSubAccountsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L663) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/subaccount-list` |
-| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L684) |  | GET | `contract/public/details` |
-| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L693) |  | GET | `contract/public/depth` |
-| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L702) |  | GET | `contract/public/open-interest` |
-| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L711) |  | GET | `contract/public/funding-rate` |
-| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L720) |  | GET | `contract/public/kline` |
-| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L735) | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
-| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L748) | :closed_lock_with_key:  | GET | `contract/private/order` |
-| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L757) | :closed_lock_with_key:  | GET | `contract/private/order-history` |
-| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L766) | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
-| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L775) | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
-| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L784) | :closed_lock_with_key:  | GET | `contract/private/position` |
-| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L793) | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
-| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L802) | :closed_lock_with_key:  | GET | `contract/private/trades` |
-| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L811) | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
-| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L822) | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
-| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L830) | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
-| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L839) | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
-| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L848) | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
-| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L859) | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
-| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L868) | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
-| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L877) | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
-| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L892) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/sub-to-main` |
-| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L904) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/main-to-sub` |
-| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L916) | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
-| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L928) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
-| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L942) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
-| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L954) | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
-| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L972) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
-| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L981) | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |
-| [getBrokerRebate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L993) | :closed_lock_with_key:  | GET | `spot/v1/broker/rebate` |
+| Function                                                                                                                   |          AUTH          | HTTP Method | Endpoint                                             |
+| -------------------------------------------------------------------------------------------------------------------------- | :--------------------: | :---------: | ---------------------------------------------------- |
+| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L209)                          |                        |     GET     | `system/time`                                        |
+| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L213)                        |                        |     GET     | `system/service`                                     |
+| [getSpotCurrenciesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L223)                    |                        |     GET     | `spot/v1/currencies`                                 |
+| [getSpotTradingPairsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L229)                  |                        |     GET     | `spot/v1/symbols`                                    |
+| [getSpotTradingPairDetailsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L233)            |                        |     GET     | `spot/v1/symbols/details`                            |
+| [getSpotTickersV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L239)                       |                        |     GET     | `spot/quotation/v3/tickers`                          |
+| [getSpotTickerV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L243)                        |                        |     GET     | `spot/quotation/v3/ticker`                           |
+| [getSpotLatestKlineV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L249)                   |                        |     GET     | `spot/quotation/v3/lite-klines`                      |
+| [getSpotHistoryKlineV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L255)                  |                        |     GET     | `spot/quotation/v3/klines`                           |
+| [getSpotOrderBookDepthV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L261)                |                        |     GET     | `spot/quotation/v3/books`                            |
+| [getSpotRecentTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L268)                    |                        |     GET     | `spot/quotation/v3/trades`                           |
+| [getSpotTickersV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L284)                       |                        |     GET     | `spot/v2/ticker`                                     |
+| [getSpotTickerV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L291)                        |                        |     GET     | `spot/v1/ticker_detail`                              |
+| [getSpotKLineStepsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L300)                    |                        |     GET     | `spot/v1/steps`                                      |
+| [getSpotKlinesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L307)                        |                        |     GET     | `spot/v1/symbols/kline`                              |
+| [getSpotOrderBookDepthV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L316)                |                        |     GET     | `spot/v1/symbols/book`                               |
+| [getAccountBalancesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L328)                   | :closed_lock_with_key: |     GET     | `account/v1/wallet`                                  |
+| [getAccountCurrenciesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L334)                 |                        |     GET     | `account/v1/currencies`                              |
+| [getSpotWalletBalanceV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L340)                 | :closed_lock_with_key: |     GET     | `spot/v1/wallet`                                     |
+| [getAccountDepositAddressV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L346)             | :closed_lock_with_key: |     GET     | `account/v1/deposit/address`                         |
+| [getAccountWithdrawQuotaV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L352)              | :closed_lock_with_key: |     GET     | `account/v1/withdraw/charge`                         |
+| [submitWithdrawalV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L358)                     | :closed_lock_with_key: |    POST     | `account/v1/withdraw/apply`                          |
+| [getWithdrawAddressList()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L364)                 | :closed_lock_with_key: |     GET     | `account/v1/withdraw/address/list`                   |
+| [getDepositWithdrawHistoryV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L372)            | :closed_lock_with_key: |     GET     | `account/v2/deposit-withdraw/history`                |
+| [getDepositWithdrawDetailV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L378)             | :closed_lock_with_key: |     GET     | `account/v1/deposit-withdraw/detail`                 |
+| [getMarginAccountDetailsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L384)              | :closed_lock_with_key: |     GET     | `spot/v1/margin/isolated/account`                    |
+| [submitMarginAssetTransferV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L390)            | :closed_lock_with_key: |    POST     | `spot/v1/margin/isolated/transfer`                   |
+| [getBasicSpotFeeRateV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L396)                  | :closed_lock_with_key: |     GET     | `spot/v1/user_fee`                                   |
+| [getActualSpotTradeFeeRateV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L400)            | :closed_lock_with_key: |     GET     | `spot/v1/trade_fee`                                  |
+| [submitSpotOrderV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L412)                      | :closed_lock_with_key: |    POST     | `spot/v2/submit_order`                               |
+| [submitMarginOrderV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L418)                    | :closed_lock_with_key: |    POST     | `spot/v1/margin/submit_order`                        |
+| [submitSpotBatchOrdersV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L427)                | :closed_lock_with_key: |    POST     | `spot/v2/batch_orders`                               |
+| [cancelSpotOrderV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L433)                      | :closed_lock_with_key: |    POST     | `spot/v3/cancel_order`                               |
+| [submitSpotBatchOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L439)                | :closed_lock_with_key: |    POST     | `spot/v4/batch_orders`                               |
+| [cancelSpotBatchOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L450)                | :closed_lock_with_key: |    POST     | `spot/v4/cancel_orders`                              |
+| [cancelAllSpotOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L456)                    | :closed_lock_with_key: |    POST     | `spot/v4/cancel_all`                                 |
+| [cancelSpotOrdersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L466)                     | :closed_lock_with_key: |    POST     | `spot/v1/cancel_orders`                              |
+| [getSpotOrderByIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L476)                     | :closed_lock_with_key: |    POST     | `spot/v4/query/order`                                |
+| [getSpotOrderByClientOrderIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L485)          | :closed_lock_with_key: |    POST     | `spot/v4/query/client-order`                         |
+| [getSpotOpenOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L491)                    | :closed_lock_with_key: |    POST     | `spot/v4/query/open-orders`                          |
+| [getSpotHistoricOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L497)                | :closed_lock_with_key: |    POST     | `spot/v4/query/history-orders`                       |
+| [getSpotAccountTradesV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L506)                 | :closed_lock_with_key: |    POST     | `spot/v4/query/trades`                               |
+| [getSpotAccountOrderTradesV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L515)            | :closed_lock_with_key: |    POST     | `spot/v4/query/order-trades`                         |
+| [submitSpotAlgoOrderV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L522)                  | :closed_lock_with_key: |    POST     | `spot/v4/algo/submit_order`                          |
+| [cancelSpotAlgoOrderV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L528)                  | :closed_lock_with_key: |    POST     | `spot/v4/algo/cancel_order`                          |
+| [cancelAllSpotAlgoOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L534)              | :closed_lock_with_key: |    POST     | `spot/v4/algo/cancel_all`                            |
+| [getSpotAlgoOrderByIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L540)                 | :closed_lock_with_key: |    POST     | `spot/v4/query/algo/order`                           |
+| [getSpotAlgoOrderByClientOrderIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L546)      | :closed_lock_with_key: |    POST     | `spot/v4/query/algo/client-order`                    |
+| [getSpotAlgoOpenOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L552)                | :closed_lock_with_key: |    POST     | `spot/v4/query/algo/open-orders`                     |
+| [getSpotAlgoHistoryOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L558)             | :closed_lock_with_key: |    POST     | `spot/v4/query/algo/history-orders`                  |
+| [marginBorrowV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L570)                         | :closed_lock_with_key: |    POST     | `spot/v1/margin/isolated/borrow`                     |
+| [marginRepayV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L576)                          | :closed_lock_with_key: |    POST     | `spot/v1/margin/isolated/repay`                      |
+| [getMarginBorrowRecordV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L582)                | :closed_lock_with_key: |     GET     | `spot/v1/margin/isolated/borrow_record`              |
+| [getMarginRepayRecordV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L588)                 | :closed_lock_with_key: |     GET     | `spot/v1/margin/isolated/repay_record`               |
+| [getMarginBorrowingRatesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L597)              | :closed_lock_with_key: |     GET     | `spot/v1/margin/isolated/pairs`                      |
+| [submitMainTransferSubToMainV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L612)          | :closed_lock_with_key: |    POST     | `account/sub-account/main/v1/sub-to-main`            |
+| [submitSubTransferSubToMainV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L621)           | :closed_lock_with_key: |    POST     | `account/sub-account/sub/v1/sub-to-main`             |
+| [submitMainTransferMainToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L627)          | :closed_lock_with_key: |    POST     | `account/sub-account/main/v1/main-to-sub`            |
+| [submitMainTransferSubToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L633)           | :closed_lock_with_key: |    POST     | `account/sub-account/main/v1/sub-to-sub`             |
+| [submitSubTransferSubToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L639)            | :closed_lock_with_key: |    POST     | `account/sub-account/sub/v1/sub-to-sub`              |
+| [getSubTransfersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L645)                      | :closed_lock_with_key: |     GET     | `account/sub-account/main/v1/transfer-list`          |
+| [getAccountSubTransfersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L651)               | :closed_lock_with_key: |     GET     | `account/sub-account/v1/transfer-history`            |
+| [getSubSpotWalletBalancesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L657)             | :closed_lock_with_key: |     GET     | `account/sub-account/main/v1/wallet`                 |
+| [getSubAccountsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L663)                       | :closed_lock_with_key: |     GET     | `account/sub-account/main/v1/subaccount-list`        |
+| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L684)              |                        |     GET     | `contract/public/details`                            |
+| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L693)                |                        |     GET     | `contract/public/depth`                              |
+| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L702)                 |                        |     GET     | `contract/public/open-interest`                      |
+| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L711)                  |                        |     GET     | `contract/public/funding-rate`                       |
+| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L720)                       |                        |     GET     | `contract/public/kline`                              |
+| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L735)                | :closed_lock_with_key: |     GET     | `contract/private/assets-detail`                     |
+| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L748)                 | :closed_lock_with_key: |     GET     | `contract/private/order`                             |
+| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L757)          | :closed_lock_with_key: |     GET     | `contract/private/order-history`                     |
+| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L766)            | :closed_lock_with_key: |     GET     | `contract/private/get-open-orders`                   |
+| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L775)            | :closed_lock_with_key: |     GET     | `contract/private/current-plan-order`                |
+| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L784)             | :closed_lock_with_key: |     GET     | `contract/private/position`                          |
+| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L793)                 | :closed_lock_with_key: |     GET     | `contract/private/position-risk`                     |
+| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L802)                | :closed_lock_with_key: |     GET     | `contract/private/trades`                            |
+| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L811)                    | :closed_lock_with_key: |     GET     | `account/v1/transfer-contract-list`                  |
+| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L822)                     | :closed_lock_with_key: |    POST     | `contract/private/submit-order`                      |
+| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L830)                     | :closed_lock_with_key: |    POST     | `contract/private/cancel-order`                      |
+| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L839)                 | :closed_lock_with_key: |    POST     | `contract/private/cancel-orders`                     |
+| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L848)                 | :closed_lock_with_key: |    POST     | `contract/private/submit-plan-order`                 |
+| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L859)                 | :closed_lock_with_key: |    POST     | `contract/private/cancel-plan-order`                 |
+| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L868)                  | :closed_lock_with_key: |    POST     | `account/v1/transfer-contract`                       |
+| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L877)                     | :closed_lock_with_key: |    POST     | `contract/private/submit-leverage`                   |
+| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L892) | :closed_lock_with_key: |    POST     | `account/contract/sub-account/main/v1/sub-to-main`   |
+| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L904) | :closed_lock_with_key: |    POST     | `account/contract/sub-account/main/v1/main-to-sub`   |
+| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L916)       | :closed_lock_with_key: |    POST     | `account/contract/sub-account/sub/v1/sub-to-main`    |
+| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L928)                    | :closed_lock_with_key: |     GET     | `account/contract/sub-account/main/v1/wallet`        |
+| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L942)                 | :closed_lock_with_key: |     GET     | `account/contract/sub-account/main/v1/transfer-list` |
+| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L954)           | :closed_lock_with_key: |     GET     | `account/contract/sub-account/v1/transfer-history`   |
+| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L972)             | :closed_lock_with_key: |     GET     | `contract/private/affiliate/rebate-list`             |
+| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L981)              | :closed_lock_with_key: |     GET     | `contract/private/affiliate/trade-list`              |
+| [getBrokerRebate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L993)                        | :closed_lock_with_key: |     GET     | `spot/v1/broker/rebate`                              |
 
 # FuturesClientV2.ts
 
-This table includes all endpoints from the official Exchange API docs and corresponding SDK functions for each endpoint that are found in [FuturesClientV2.ts](/src/FuturesClientV2.ts). 
+This table includes all endpoints from the official Exchange API docs and corresponding SDK functions for each endpoint that are found in [FuturesClientV2.ts](/src/FuturesClientV2.ts).
 
-| Function | AUTH | HTTP Method | Endpoint |
-| -------- | :------: | :------: | -------- |
-| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L103) |  | GET | `system/time` |
-| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L107) |  | GET | `system/service` |
-| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L128) |  | GET | `contract/public/details` |
-| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L134) |  | GET | `contract/public/depth` |
-| [getFuturesMarketTrade()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L140) |  | GET | `contract/public/market-trade` |
-| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L147) |  | GET | `contract/public/open-interest` |
-| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L153) |  | GET | `contract/public/funding-rate` |
-| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L159) |  | GET | `contract/public/kline` |
-| [getFuturesMarkPriceKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L165) |  | GET | `contract/public/markprice-kline` |
-| [getFuturesFundingRateHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L171) |  | GET | `contract/public/funding-rate-history` |
-| [getFuturesLeverageBracket()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L187) |  | GET | `contract/public/leverage-bracket` |
-| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L201) | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
-| [getFuturesTradeFeeRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L211) | :closed_lock_with_key:  | GET | `contract/private/trade-fee-rate` |
-| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L221) | :closed_lock_with_key:  | GET | `contract/private/order` |
-| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L227) | :closed_lock_with_key:  | GET | `contract/private/order-history` |
-| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L233) | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
-| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L239) | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
-| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L245) | :closed_lock_with_key:  | GET | `contract/private/position` |
-| [getFuturesAccountPositionsV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L252) | :closed_lock_with_key:  | GET | `contract/private/position-v2` |
-| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L262) | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
-| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L269) | :closed_lock_with_key:  | GET | `contract/private/trades` |
-| [getFuturesAccountTransactionHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L275) | :closed_lock_with_key:  | GET | `contract/private/transaction-history` |
-| [getFuturesAutoRepayment()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L284) | :closed_lock_with_key:  | GET | `contract/private/auto_repayment` |
-| [getFuturesCrossCollateralInterestLog()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L293) | :closed_lock_with_key:  | GET | `contract/private/cross_collateral/interest_log` |
-| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L302) | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
-| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L310) | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
-| [updateFuturesLimitOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L316) | :closed_lock_with_key:  | POST | `contract/private/modify-limit-order` |
-| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L325) | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
-| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L331) | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
-| [cancelAllFuturesOrdersAfter()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L337) | :closed_lock_with_key:  | POST | `contract/private/cancel-all-after` |
-| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L344) | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
-| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L352) | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
-| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L358) | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
-| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L364) | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
-| [submitFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L370) | :closed_lock_with_key:  | POST | `contract/private/submit-tp-sl-order` |
-| [updateFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L379) | :closed_lock_with_key:  | POST | `contract/private/modify-plan-order` |
-| [updateFuturesPresetPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L387) | :closed_lock_with_key:  | POST | `contract/private/modify-preset-plan-order` |
-| [updateFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L400) | :closed_lock_with_key:  | POST | `contract/private/modify-tp-sl-order` |
-| [submitFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L408) | :closed_lock_with_key:  | POST | `contract/private/submit-trail-order` |
-| [cancelFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L416) | :closed_lock_with_key:  | POST | `contract/private/cancel-trail-order` |
-| [setPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L425) | :closed_lock_with_key:  | POST | `contract/private/set-position-mode` |
-| [getPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L434) | :closed_lock_with_key:  | GET | `contract/private/get-position-mode` |
-| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L446) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/sub-to-main` |
-| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L455) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/main-to-sub` |
-| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L464) | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
-| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L473) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
-| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L484) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
-| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L493) | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
-| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L508) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
-| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L514) | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |
-| [getFuturesAffiliateRebateUser()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L525) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-inviteUser` |
-| [getFuturesAffiliateRebateApi()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L539) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-api` |
-| [getFuturesAffiliateDepositWithdrawalList()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L549) | :closed_lock_with_key:  | GET | `contract/private/affiliate/deposit-withdrawal-list` |
-| [submitFuturesSimulatedClaim()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L574) | :closed_lock_with_key:  | POST | `contract/private/claim` |
+| Function                                                                                                                          |          AUTH          | HTTP Method | Endpoint                                             |
+| --------------------------------------------------------------------------------------------------------------------------------- | :--------------------: | :---------: | ---------------------------------------------------- |
+| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L103)                            |                        |     GET     | `system/time`                                        |
+| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L107)                          |                        |     GET     | `system/service`                                     |
+| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L128)                |                        |     GET     | `contract/public/details`                            |
+| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L134)                  |                        |     GET     | `contract/public/depth`                              |
+| [getFuturesMarketTrade()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L140)                    |                        |     GET     | `contract/public/market-trade`                       |
+| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L147)                   |                        |     GET     | `contract/public/open-interest`                      |
+| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L153)                    |                        |     GET     | `contract/public/funding-rate`                       |
+| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L159)                         |                        |     GET     | `contract/public/kline`                              |
+| [getFuturesMarkPriceKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L165)                |                        |     GET     | `contract/public/markprice-kline`                    |
+| [getFuturesFundingRateHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L171)             |                        |     GET     | `contract/public/funding-rate-history`               |
+| [getFuturesLeverageBracket()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L187)                |                        |     GET     | `contract/public/leverage-bracket`                   |
+| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L201)                  | :closed_lock_with_key: |     GET     | `contract/private/assets-detail`                     |
+| [getFuturesTradeFeeRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L211)                   | :closed_lock_with_key: |     GET     | `contract/private/trade-fee-rate`                    |
+| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L221)                   | :closed_lock_with_key: |     GET     | `contract/private/order`                             |
+| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L227)            | :closed_lock_with_key: |     GET     | `contract/private/order-history`                     |
+| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L233)              | :closed_lock_with_key: |     GET     | `contract/private/get-open-orders`                   |
+| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L239)              | :closed_lock_with_key: |     GET     | `contract/private/current-plan-order`                |
+| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L245)               | :closed_lock_with_key: |     GET     | `contract/private/position`                          |
+| [getFuturesAccountPositionsV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L252)             | :closed_lock_with_key: |     GET     | `contract/private/position-v2`                       |
+| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L262)                   | :closed_lock_with_key: |     GET     | `contract/private/position-risk`                     |
+| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L269)                  | :closed_lock_with_key: |     GET     | `contract/private/trades`                            |
+| [getFuturesAccountTransactionHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L275)      | :closed_lock_with_key: |     GET     | `contract/private/transaction-history`               |
+| [getFuturesAutoRepayment()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L284)                  | :closed_lock_with_key: |     GET     | `contract/private/auto_repayment`                    |
+| [getFuturesCrossCollateralInterestLog()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L293)     | :closed_lock_with_key: |     GET     | `contract/private/cross_collateral/interest_log`     |
+| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L302)                      | :closed_lock_with_key: |     GET     | `account/v1/transfer-contract-list`                  |
+| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L310)                       | :closed_lock_with_key: |    POST     | `contract/private/submit-order`                      |
+| [updateFuturesLimitOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L316)                  | :closed_lock_with_key: |    POST     | `contract/private/modify-limit-order`                |
+| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L325)                       | :closed_lock_with_key: |    POST     | `contract/private/cancel-order`                      |
+| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L331)                   | :closed_lock_with_key: |    POST     | `contract/private/cancel-orders`                     |
+| [cancelAllFuturesOrdersAfter()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L337)              | :closed_lock_with_key: |    POST     | `contract/private/cancel-all-after`                  |
+| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L344)                   | :closed_lock_with_key: |    POST     | `contract/private/submit-plan-order`                 |
+| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L352)                   | :closed_lock_with_key: |    POST     | `contract/private/cancel-plan-order`                 |
+| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L358)                    | :closed_lock_with_key: |    POST     | `account/v1/transfer-contract`                       |
+| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L364)                       | :closed_lock_with_key: |    POST     | `contract/private/submit-leverage`                   |
+| [submitFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L370)                   | :closed_lock_with_key: |    POST     | `contract/private/submit-tp-sl-order`                |
+| [updateFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L379)                   | :closed_lock_with_key: |    POST     | `contract/private/modify-plan-order`                 |
+| [updateFuturesPresetPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L387)             | :closed_lock_with_key: |    POST     | `contract/private/modify-preset-plan-order`          |
+| [updateFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L400)                   | :closed_lock_with_key: |    POST     | `contract/private/modify-tp-sl-order`                |
+| [submitFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L408)                  | :closed_lock_with_key: |    POST     | `contract/private/submit-trail-order`                |
+| [cancelFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L416)                  | :closed_lock_with_key: |    POST     | `contract/private/cancel-trail-order`                |
+| [setPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L425)                          | :closed_lock_with_key: |    POST     | `contract/private/set-position-mode`                 |
+| [getPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L434)                          | :closed_lock_with_key: |     GET     | `contract/private/get-position-mode`                 |
+| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L446)   | :closed_lock_with_key: |    POST     | `account/contract/sub-account/main/v1/sub-to-main`   |
+| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L455)   | :closed_lock_with_key: |    POST     | `account/contract/sub-account/main/v1/main-to-sub`   |
+| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L464)         | :closed_lock_with_key: |    POST     | `account/contract/sub-account/sub/v1/sub-to-main`    |
+| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L473)                      | :closed_lock_with_key: |     GET     | `account/contract/sub-account/main/v1/wallet`        |
+| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L484)                   | :closed_lock_with_key: |     GET     | `account/contract/sub-account/main/v1/transfer-list` |
+| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L493)             | :closed_lock_with_key: |     GET     | `account/contract/sub-account/v1/transfer-history`   |
+| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L510)               | :closed_lock_with_key: |     GET     | `contract/private/affiliate/rebate-list`             |
+| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L516)                | :closed_lock_with_key: |     GET     | `contract/private/affiliate/trade-list`              |
+| [getFuturesAffiliateRebateUser()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L526)            | :closed_lock_with_key: |     GET     | `contract/private/affiliate/rebate-user`             |
+| [getFuturesAffiliateRebateInviteUser()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L537)      | :closed_lock_with_key: |     GET     | `contract/private/affiliate/rebate-inviteUser`       |
+| [getFuturesAffiliateRebateApi()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L551)             | :closed_lock_with_key: |     GET     | `contract/private/affiliate/rebate-api`              |
+| [getFuturesAffiliateDepositWithdrawalList()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L561) | :closed_lock_with_key: |     GET     | `contract/private/affiliate/deposit-withdrawal-list` |
+| [submitFuturesSimulatedClaim()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L586)              | :closed_lock_with_key: |    POST     | `contract/private/claim`                             |

--- a/examples/apidoc/FuturesClientV2/getFuturesAffiliateDepositWithdrawalList.js
+++ b/examples/apidoc/FuturesClientV2/getFuturesAffiliateDepositWithdrawalList.js
@@ -2,7 +2,7 @@ const { FuturesClientV2 } = require('bitmart-api');
 
   // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
   // This bitmart API SDK is available on npm via "npm install bitmart-api"
-  // ENDPOINT: contract/private/affiliate/rebate-inviteUser
+  // ENDPOINT: contract/private/affiliate/deposit-withdrawal-list
   // METHOD: GET
   // PUBLIC: NO
 
@@ -12,7 +12,7 @@ const client = new FuturesClientV2({
   apiMemo: 'yourAPIMemoHere',
 });
 
-client.getFuturesAffiliateRebateUser(params)
+client.getFuturesAffiliateDepositWithdrawalList(params)
   .then((response) => {
     console.log(response);
   })

--- a/examples/apidoc/FuturesClientV2/getFuturesAffiliateRebateInviteUser.js
+++ b/examples/apidoc/FuturesClientV2/getFuturesAffiliateRebateInviteUser.js
@@ -2,7 +2,7 @@ const { FuturesClientV2 } = require('bitmart-api');
 
 // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
 // This bitmart API SDK is available on npm via "npm install bitmart-api"
-// ENDPOINT: contract/private/affiliate/rebate-user
+// ENDPOINT: contract/private/affiliate/rebate-inviteUser
 // METHOD: GET
 // PUBLIC: NO
 
@@ -13,10 +13,11 @@ const client = new FuturesClientV2({
 });
 
 client
-  .getFuturesAffiliateRebateUser({
-    cid: 1000000,
+  .getFuturesAffiliateRebateInviteUser({
     start_time: 1000000000,
     end_time: 2000000000,
+    page: 1,
+    size: 10,
   })
   .then((response) => {
     console.log(response);

--- a/examples/apidoc/FuturesClientV2/getFuturesAutoRepayment.js
+++ b/examples/apidoc/FuturesClientV2/getFuturesAutoRepayment.js
@@ -2,7 +2,7 @@ const { FuturesClientV2 } = require('bitmart-api');
 
   // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
   // This bitmart API SDK is available on npm via "npm install bitmart-api"
-  // ENDPOINT: contract/private/affiliate/rebate-inviteUser
+  // ENDPOINT: contract/private/auto_repayment
   // METHOD: GET
   // PUBLIC: NO
 
@@ -12,7 +12,7 @@ const client = new FuturesClientV2({
   apiMemo: 'yourAPIMemoHere',
 });
 
-client.getFuturesAffiliateRebateUser(params)
+client.getFuturesAutoRepayment(params)
   .then((response) => {
     console.log(response);
   })

--- a/examples/apidoc/FuturesClientV2/getFuturesCrossCollateralInterestLog.js
+++ b/examples/apidoc/FuturesClientV2/getFuturesCrossCollateralInterestLog.js
@@ -2,7 +2,7 @@ const { FuturesClientV2 } = require('bitmart-api');
 
   // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
   // This bitmart API SDK is available on npm via "npm install bitmart-api"
-  // ENDPOINT: contract/private/affiliate/rebate-inviteUser
+  // ENDPOINT: contract/private/cross_collateral/interest_log
   // METHOD: GET
   // PUBLIC: NO
 
@@ -12,7 +12,7 @@ const client = new FuturesClientV2({
   apiMemo: 'yourAPIMemoHere',
 });
 
-client.getFuturesAffiliateRebateUser(params)
+client.getFuturesCrossCollateralInterestLog(params)
   .then((response) => {
     console.log(response);
   })

--- a/examples/apidoc/RestClient/cancelAllSpotAlgoOrdersV4.js
+++ b/examples/apidoc/RestClient/cancelAllSpotAlgoOrdersV4.js
@@ -1,18 +1,18 @@
-const { FuturesClientV2 } = require('bitmart-api');
+const { RestClient } = require('bitmart-api');
 
   // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
   // This bitmart API SDK is available on npm via "npm install bitmart-api"
-  // ENDPOINT: contract/private/affiliate/rebate-inviteUser
-  // METHOD: GET
+  // ENDPOINT: spot/v4/algo/cancel_all
+  // METHOD: POST
   // PUBLIC: NO
 
-const client = new FuturesClientV2({
+const client = new RestClient({
   apiKey: 'yourAPIKeyHere',
   apiSecret: 'yourAPISecretHere',
   apiMemo: 'yourAPIMemoHere',
 });
 
-client.getFuturesAffiliateRebateUser(params)
+client.cancelAllSpotAlgoOrdersV4(params)
   .then((response) => {
     console.log(response);
   })

--- a/examples/apidoc/RestClient/cancelSpotAlgoOrderV4.js
+++ b/examples/apidoc/RestClient/cancelSpotAlgoOrderV4.js
@@ -1,18 +1,18 @@
-const { FuturesClientV2 } = require('bitmart-api');
+const { RestClient } = require('bitmart-api');
 
   // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
   // This bitmart API SDK is available on npm via "npm install bitmart-api"
-  // ENDPOINT: contract/private/affiliate/rebate-inviteUser
-  // METHOD: GET
+  // ENDPOINT: spot/v4/algo/cancel_order
+  // METHOD: POST
   // PUBLIC: NO
 
-const client = new FuturesClientV2({
+const client = new RestClient({
   apiKey: 'yourAPIKeyHere',
   apiSecret: 'yourAPISecretHere',
   apiMemo: 'yourAPIMemoHere',
 });
 
-client.getFuturesAffiliateRebateUser(params)
+client.cancelSpotAlgoOrderV4(params)
   .then((response) => {
     console.log(response);
   })

--- a/examples/apidoc/RestClient/getSpotAlgoHistoryOrdersV4.js
+++ b/examples/apidoc/RestClient/getSpotAlgoHistoryOrdersV4.js
@@ -1,18 +1,18 @@
-const { FuturesClientV2 } = require('bitmart-api');
+const { RestClient } = require('bitmart-api');
 
   // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
   // This bitmart API SDK is available on npm via "npm install bitmart-api"
-  // ENDPOINT: contract/private/affiliate/rebate-inviteUser
-  // METHOD: GET
+  // ENDPOINT: spot/v4/query/algo/history-orders
+  // METHOD: POST
   // PUBLIC: NO
 
-const client = new FuturesClientV2({
+const client = new RestClient({
   apiKey: 'yourAPIKeyHere',
   apiSecret: 'yourAPISecretHere',
   apiMemo: 'yourAPIMemoHere',
 });
 
-client.getFuturesAffiliateRebateUser(params)
+client.getSpotAlgoHistoryOrdersV4(params)
   .then((response) => {
     console.log(response);
   })

--- a/examples/apidoc/RestClient/getSpotAlgoOpenOrdersV4.js
+++ b/examples/apidoc/RestClient/getSpotAlgoOpenOrdersV4.js
@@ -1,18 +1,18 @@
-const { FuturesClientV2 } = require('bitmart-api');
+const { RestClient } = require('bitmart-api');
 
   // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
   // This bitmart API SDK is available on npm via "npm install bitmart-api"
-  // ENDPOINT: contract/private/affiliate/rebate-inviteUser
-  // METHOD: GET
+  // ENDPOINT: spot/v4/query/algo/open-orders
+  // METHOD: POST
   // PUBLIC: NO
 
-const client = new FuturesClientV2({
+const client = new RestClient({
   apiKey: 'yourAPIKeyHere',
   apiSecret: 'yourAPISecretHere',
   apiMemo: 'yourAPIMemoHere',
 });
 
-client.getFuturesAffiliateRebateUser(params)
+client.getSpotAlgoOpenOrdersV4(params)
   .then((response) => {
     console.log(response);
   })

--- a/examples/apidoc/RestClient/getSpotAlgoOrderByClientOrderIdV4.js
+++ b/examples/apidoc/RestClient/getSpotAlgoOrderByClientOrderIdV4.js
@@ -1,18 +1,18 @@
-const { FuturesClientV2 } = require('bitmart-api');
+const { RestClient } = require('bitmart-api');
 
   // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
   // This bitmart API SDK is available on npm via "npm install bitmart-api"
-  // ENDPOINT: contract/private/affiliate/rebate-inviteUser
-  // METHOD: GET
+  // ENDPOINT: spot/v4/query/algo/client-order
+  // METHOD: POST
   // PUBLIC: NO
 
-const client = new FuturesClientV2({
+const client = new RestClient({
   apiKey: 'yourAPIKeyHere',
   apiSecret: 'yourAPISecretHere',
   apiMemo: 'yourAPIMemoHere',
 });
 
-client.getFuturesAffiliateRebateUser(params)
+client.getSpotAlgoOrderByClientOrderIdV4(params)
   .then((response) => {
     console.log(response);
   })

--- a/examples/apidoc/RestClient/getSpotAlgoOrderByIdV4.js
+++ b/examples/apidoc/RestClient/getSpotAlgoOrderByIdV4.js
@@ -1,18 +1,18 @@
-const { FuturesClientV2 } = require('bitmart-api');
+const { RestClient } = require('bitmart-api');
 
   // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
   // This bitmart API SDK is available on npm via "npm install bitmart-api"
-  // ENDPOINT: contract/private/affiliate/rebate-inviteUser
-  // METHOD: GET
+  // ENDPOINT: spot/v4/query/algo/order
+  // METHOD: POST
   // PUBLIC: NO
 
-const client = new FuturesClientV2({
+const client = new RestClient({
   apiKey: 'yourAPIKeyHere',
   apiSecret: 'yourAPISecretHere',
   apiMemo: 'yourAPIMemoHere',
 });
 
-client.getFuturesAffiliateRebateUser(params)
+client.getSpotAlgoOrderByIdV4(params)
   .then((response) => {
     console.log(response);
   })

--- a/examples/apidoc/RestClient/submitSpotAlgoOrderV4.js
+++ b/examples/apidoc/RestClient/submitSpotAlgoOrderV4.js
@@ -1,18 +1,18 @@
-const { FuturesClientV2 } = require('bitmart-api');
+const { RestClient } = require('bitmart-api');
 
   // This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
   // This bitmart API SDK is available on npm via "npm install bitmart-api"
-  // ENDPOINT: contract/private/affiliate/rebate-inviteUser
-  // METHOD: GET
+  // ENDPOINT: spot/v4/algo/submit_order
+  // METHOD: POST
   // PUBLIC: NO
 
-const client = new FuturesClientV2({
+const client = new RestClient({
   apiKey: 'yourAPIKeyHere',
   apiSecret: 'yourAPISecretHere',
   apiMemo: 'yourAPIMemoHere',
 });
 
-client.getFuturesAffiliateRebateUser(params)
+client.submitSpotAlgoOrderV4(params)
   .then((response) => {
     console.log(response);
   })

--- a/llms.txt
+++ b/llms.txt
@@ -713,6 +713,60 @@ export interface SpotBrokerRebateRequest {
   start_time?: number;
   end_time?: number;
 }
+⋮----
+/** Spot algo order (v4): TP/SL or trigger. See `POST spot/v4/algo/submit_order`. */
+export interface SubmitSpotAlgoOrderV4Request {
+  symbol: string;
+  side: 'buy' | 'sell';
+  type: 'tp/sl' | 'trigger';
+  client_order_id?: string;
+  trigger_price?: string;
+  trigger_type?: 'limit' | 'market';
+  price?: string;
+  notional?: string;
+  size?: string;
+}
+⋮----
+export interface CancelSpotAlgoOrderV4Request {
+  symbol: string;
+  order_id: string;
+  type: 'tp/sl' | 'trigger';
+}
+⋮----
+export interface CancelAllSpotAlgoOrdersV4Request {
+  symbol?: string;
+  type: 'tp/sl' | 'trigger';
+}
+⋮----
+export interface SpotAlgoOrderByIdV4Request {
+  orderId: string;
+  queryState?: 'open' | 'history';
+  recvWindow?: number;
+}
+⋮----
+export interface SpotAlgoOrderByClientOrderIdV4Request {
+  clientOrderId: string;
+  queryState?: 'open' | 'history';
+  recvWindow?: number;
+}
+⋮----
+export interface SpotAlgoOpenOrdersV4Request {
+  symbol?: string;
+  orderMode?: 'trigger' | 'tp/sl';
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  recvWindow?: number;
+}
+⋮----
+export interface SpotAlgoHistoryOrdersV4Request {
+  symbol?: string;
+  orderMode?: 'trigger' | 'tp/sl';
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  recvWindow?: number;
+}
 
 ================
 File: webpack/webpack.config.cjs
@@ -936,6 +990,43 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================
+File: tsconfig.json
+================
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "noEmitOnError": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": false,
+    "inlineSourceMap": false,
+    "lib": ["esnext"],
+    "listEmittedFiles": false,
+    "listFiles": false,
+    "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noUnusedParameters": true,
+    "pretty": true,
+    "removeComments": false,
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "skipLibCheck": false,
+    "sourceMap": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "types": ["node", "jest"],
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "esnext"
+  },
+  "compileOnSave": true,
+  "exclude": ["node_modules", "dist", "test"],
+  "include": ["src/**/*.*", ".eslintrc.cjs"]
+}
 
 ================
 File: tsconfig.linting.json
@@ -1520,9 +1611,38 @@ export interface SubmitFuturesTrailOrderRequest {
 }
 ⋮----
 export interface FuturesAffiliateRebateUserRequest {
+  cid?: number;
+  start_time: number;
+  end_time: number;
+  page: number;
+  size: number;
+}
+⋮----
+/** Affiliate invited users deposit / withdrawal records (max 60 days, size max 50). */
+export interface FuturesAffiliateDepositWithdrawalListRequest {
+  page: number;
+  size: number;
+  type?: 1 | 2;
   cid: number;
   start_time: number;
   end_time: number;
+}
+⋮----
+export interface FuturesAutoRepaymentRequest {
+  start_time?: number;
+  end_time?: number;
+  page?: number;
+  size?: number;
+  from_coin_code?: string;
+  type?: string;
+}
+⋮----
+export interface FuturesCrossCollateralInterestLogRequest {
+  start_time?: number;
+  end_time?: number;
+  page?: number;
+  size?: number;
+  coin_code?: string;
 }
 ⋮----
 export interface FuturesAffiliateRebateApiRequest {
@@ -1864,6 +1984,25 @@ export interface SpotTradeBase {
   cancelSource: string;
 }
 ⋮----
+/**
+ * Spot algo order (v4): trigger or TP/SL. Returned by algo query endpoints.
+ */
+export interface SpotAlgoOrderV4 {
+  orderId: string;
+  clientOrderId: string;
+  symbol: string;
+  side: OrderSide;
+  orderMode: string;
+  trigger_type: string;
+  state: string;
+  cancelSource: string;
+  price: string;
+  size: string;
+  notional: string;
+  createTime: number;
+  updateTime: number;
+}
+⋮----
 export interface SpotOrderV4 extends SpotTradeBase {
   state: string;
   priceAvg: string;
@@ -1972,41 +2111,18 @@ File: .eslintrc.cjs
 // 'no-unused-vars': ['warn'],
 
 ================
-File: tsconfig.json
+File: .gitignore
 ================
-{
-  "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
-    "noEmitOnError": true,
-    "declaration": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": false,
-    "inlineSourceMap": false,
-    "lib": ["esnext"],
-    "listEmittedFiles": false,
-    "listFiles": false,
-    "moduleResolution": "node",
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
-    "noUnusedParameters": true,
-    "pretty": true,
-    "removeComments": false,
-    "resolveJsonModule": true,
-    "rootDir": "src",
-    "skipLibCheck": false,
-    "sourceMap": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "types": ["node", "jest"],
-    "module": "commonjs",
-    "outDir": "dist/cjs",
-    "target": "esnext"
-  },
-  "compileOnSave": true,
-  "exclude": ["node_modules", "dist", "test"],
-  "include": ["src/**/*.*", ".eslintrc.cjs"]
-}
+spot-private-test.ts
+node_modules
+futures-private-test.ts
+signTest.ts
+privaterepotracker
+restClientRegex.ts
+testfile.ts
+dist
+repomix.sh
+doc
 
 ================
 File: src/lib/websocket/WsStore.ts
@@ -2216,12 +2332,18 @@ import {
 } from './types/request/futures.types.js';
 import {
   AccountSubTransfersV1Request,
+  CancelAllSpotAlgoOrdersV4Request,
   CancelOrdersV3Request,
+  CancelSpotAlgoOrderV4Request,
   CancelSpotBatchOrdersV4Request,
   DepositWithdrawHistoryV2Request,
   MarginBorrowRecordsV1Request,
   MarginBorrowRepayV1Request,
   MarginRepayRecordsV1Request,
+  SpotAlgoHistoryOrdersV4Request,
+  SpotAlgoOpenOrdersV4Request,
+  SpotAlgoOrderByClientOrderIdV4Request,
+  SpotAlgoOrderByIdV4Request,
   SpotBrokerRebateRequest,
   SpotKlinesV1Request,
   SpotKlineV3Request,
@@ -2232,6 +2354,7 @@ import {
   SpotOrderTradeHistoryV4Request,
   SubmitMainTransferSubToSubV1Request,
   SubmitMarginTransferV1Request,
+  SubmitSpotAlgoOrderV4Request,
   SubmitSpotBatchOrdersV4Request,
   SubmitSpotOrderV2Request,
   SubmitSubTransferSubToMainV1Request,
@@ -2281,6 +2404,7 @@ import {
   MarginRepayRecordV1,
   ServiceStatus,
   SpotAccountTradeV4,
+  SpotAlgoOrderV4,
   SpotBrokerRebateResult,
   SpotCurrencyV1,
   SpotKlineV1,
@@ -2568,6 +2692,34 @@ getSpotAccountOrderTradesV4(params: {
     orderId: string;
     recvWindow?: number;
 }): Promise<APIResponse<SpotAccountTradeV4[]>>
+⋮----
+submitSpotAlgoOrderV4(
+    params: SubmitSpotAlgoOrderV4Request,
+): Promise<APIResponse<
+⋮----
+cancelSpotAlgoOrderV4(
+    params: CancelSpotAlgoOrderV4Request,
+): Promise<APIResponse<
+⋮----
+cancelAllSpotAlgoOrdersV4(
+    params: CancelAllSpotAlgoOrdersV4Request,
+): Promise<APIResponse<
+⋮----
+getSpotAlgoOrderByIdV4(
+    params: SpotAlgoOrderByIdV4Request,
+): Promise<APIResponse<SpotAlgoOrderV4>>
+⋮----
+getSpotAlgoOrderByClientOrderIdV4(
+    params: SpotAlgoOrderByClientOrderIdV4Request,
+): Promise<APIResponse<SpotAlgoOrderV4>>
+⋮----
+getSpotAlgoOpenOrdersV4(
+    params?: SpotAlgoOpenOrdersV4Request,
+): Promise<APIResponse<SpotAlgoOrderV4[]>>
+⋮----
+getSpotAlgoHistoryOrdersV4(
+    params?: SpotAlgoHistoryOrdersV4Request,
+): Promise<APIResponse<SpotAlgoOrderV4[]>>
 ⋮----
 /**
    *
@@ -2907,20 +3059,6 @@ getFuturesAffiliateTrades(
 getBrokerRebate(
     params?: SpotBrokerRebateRequest,
 ): Promise<APIResponse<SpotBrokerRebateResult>>
-
-================
-File: .gitignore
-================
-spot-private-test.ts
-node_modules
-futures-private-test.ts
-signTest.ts
-privaterepotracker
-restClientRegex.ts
-testfile.ts
-dist
-repomix.sh
-doc
 
 ================
 File: src/lib/BaseRestClient.ts
@@ -3551,15 +3689,86 @@ export interface FuturesAccountSubTransfer {
   submissionTime: number;
 }
 ⋮----
-export interface FuturesAffiliateRebateUserResponse {
+/** Row from GET `contract/private/affiliate/rebate-inviteUser` (invite customer list). */
+export interface FuturesAffiliateRebateInviteUserRow {
+  rebateTotal: string;
+  tradingVolTotal: string;
+  cashbackRate: string;
+  tradingFeeTotal: string;
+  backRate: string;
   cid: number;
-  back_rate: string;
-  trading_vol_total: string;
-  trading_fee_total: string;
-  rebate_total: string;
-  trading_vol: string;
-  trading_fee: string;
-  rebate: string;
+  status: number;
+  accountAssetTotal: string;
+}
+⋮----
+/** `data` payload for GET `contract/private/affiliate/rebate-inviteUser`. */
+export interface FuturesAffiliateRebateUserResponse {
+  list: FuturesAffiliateRebateInviteUserRow[];
+  page: number;
+  size: number;
+  total: number;
+}
+⋮----
+export interface FuturesAffiliateDepositWithdrawalListItem {
+  dateTime: number;
+  cid: number;
+  remark: string;
+  parentCid: number;
+  userType: number;
+  type: number;
+  method: number;
+  amount: string;
+  coin: string;
+}
+⋮----
+export interface FuturesAffiliateDepositWithdrawalListResult {
+  total: number;
+  size: number;
+  page: number;
+  list: FuturesAffiliateDepositWithdrawalListItem[];
+}
+⋮----
+export interface FuturesAutoRepaymentRecord {
+  to_coin_code: string;
+  to_amount: string;
+  from_coin_code: string;
+  from_amount: string;
+  time: string;
+  type: string;
+  liquidation_fee: string;
+}
+⋮----
+export interface FuturesAutoRepaymentApiResponse {
+  errno: string;
+  message: string;
+  data: {
+    list: FuturesAutoRepaymentRecord[];
+    total: number;
+  };
+  success: boolean;
+}
+⋮----
+export interface FuturesCrossCollateralInterestLogItem {
+  id: number;
+  account_id: number;
+  coin_code: string;
+  rate: string;
+  interest: string;
+  liability: string;
+  interest_time: number;
+  created_at: string;
+  updated_at: string;
+  interest_free_amount: string;
+}
+⋮----
+export interface FuturesCrossCollateralInterestLogApiResponse {
+  errno: string;
+  message: string;
+  data: {
+    items: FuturesCrossCollateralInterestLogItem[];
+    total: number;
+  };
+  success: boolean;
 }
 ⋮----
 export interface FuturesAffiliateRebateApiResponse {
@@ -3734,10 +3943,13 @@ import {
   FuturesAccountPlanOrdersRequest,
   FuturesAccountTradesRequest,
   FuturesAccountTransfersRequest,
+  FuturesAffiliateDepositWithdrawalListRequest,
   FuturesAffiliateRebateApiRequest,
   FuturesAffiliateRebatesRequest,
   FuturesAffiliateRebateUserRequest,
   FuturesAffiliateTradesRequest,
+  FuturesAutoRepaymentRequest,
+  FuturesCrossCollateralInterestLogRequest,
   FuturesKlinesRequest,
   FuturesSubTransfersRequest,
   FuturesSubWalletRequest,
@@ -3769,10 +3981,13 @@ import {
   FuturesAccountSubTransfer,
   FuturesAccountTrade,
   FuturesAccountTransfer,
+  FuturesAffiliateDepositWithdrawalListResult,
   FuturesAffiliateRebateApiResponse,
   FuturesAffiliateRebateUserResponse,
+  FuturesAutoRepaymentApiResponse,
   FuturesContractDepth,
   FuturesContractDetails,
+  FuturesCrossCollateralInterestLogApiResponse,
   FuturesFundingRate,
   FuturesFundingRateHistory,
   FuturesKline,
@@ -3947,6 +4162,20 @@ getFuturesAccountTransactionHistory(
     params: FuturesAccountHistoricTransactionRequest,
 ): Promise<APIResponse<FuturesAccountHistoricTransaction[]>>
 ⋮----
+/**
+   * Query auto repayment records (KEYED). Defaults to last 7 days if times omitted; max 20 records per request.
+   */
+getFuturesAutoRepayment(
+    params?: FuturesAutoRepaymentRequest,
+): Promise<FuturesAutoRepaymentApiResponse>
+⋮----
+/**
+   * Query cross margin interest accrual logs (KEYED). Defaults to last 7 days; max interval 90 days; max 20 records per request.
+   */
+getFuturesCrossCollateralInterestLog(
+    params?: FuturesCrossCollateralInterestLogRequest,
+): Promise<FuturesCrossCollateralInterestLogApiResponse>
+⋮----
 getFuturesTransfers(params: FuturesAccountTransfersRequest): Promise<
     APIResponse<{
       records: FuturesAccountTransfer[];
@@ -4111,9 +4340,9 @@ getFuturesAffiliateTrades(
 ): Promise<APIResponse<any>>
 ⋮----
 /**
-   * Get User Rebate Data (KEYED)
-   * Used for API affiliates to query contract rebate data within a certain time range
-   * Feature: Query up to 60 days of data
+   * Get invited customer list (KEYED)
+   * Used by agents to query rebate information of invited users within a specified time range.
+   * Feature: Query up to 60 days of data; list entries include `accountAssetTotal` (exchange update 2026-04-07).
    */
 getFuturesAffiliateRebateUser(
     params: FuturesAffiliateRebateUserRequest,
@@ -4127,6 +4356,14 @@ getFuturesAffiliateRebateUser(
 getFuturesAffiliateRebateApi(
     params: FuturesAffiliateRebateApiRequest,
 ): Promise<APIResponse<FuturesAffiliateRebateApiResponse>>
+⋮----
+/**
+   * Deposit and withdrawal information of invited users (KEYED)
+   * Feature: Query up to 60 days; max 50 records per page (exchange update 2026-04-07).
+   */
+getFuturesAffiliateDepositWithdrawalList(
+    params: FuturesAffiliateDepositWithdrawalListRequest,
+): Promise<FuturesAffiliateDepositWithdrawalListResult>
 ⋮----
 /**
    * Simulated Claim (SIGNED)
@@ -5497,7 +5734,7 @@ File: package.json
 ================
 {
   "name": "bitmart-api",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Complete & robust Node.js SDK for BitMart's REST APIs and WebSockets, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitmart-api",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitmart-api",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmart-api",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Complete & robust Node.js SDK for BitMart's REST APIs and WebSockets, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/src/FuturesClientV2.ts
+++ b/src/FuturesClientV2.ts
@@ -18,6 +18,7 @@ import {
   FuturesAccountTransfersRequest,
   FuturesAffiliateDepositWithdrawalListRequest,
   FuturesAffiliateRebateApiRequest,
+  FuturesAffiliateRebateInviteUserRequest,
   FuturesAffiliateRebatesRequest,
   FuturesAffiliateRebateUserRequest,
   FuturesAffiliateTradesRequest,
@@ -56,6 +57,7 @@ import {
   FuturesAccountTransfer,
   FuturesAffiliateDepositWithdrawalListResult,
   FuturesAffiliateRebateApiResponse,
+  FuturesAffiliateRebateInviteUserResponse,
   FuturesAffiliateRebateUserResponse,
   FuturesAutoRepaymentApiResponse,
   FuturesContractDepth,
@@ -518,13 +520,23 @@ export class FuturesClientV2 extends BaseRestClient {
   }
 
   /**
-   * Get invited customer list (KEYED)
-   * Used by agents to query rebate information of invited users within a specified time range.
-   * Feature: Query up to 60 days of data; list entries include `accountAssetTotal` (exchange update 2026-04-07).
+   * Get single user rebate data (KEYED)
+   * GET `contract/private/affiliate/rebate-user`
    */
   getFuturesAffiliateRebateUser(
     params: FuturesAffiliateRebateUserRequest,
   ): Promise<APIResponse<FuturesAffiliateRebateUserResponse>> {
+    return this.getPrivate('contract/private/affiliate/rebate-user', params);
+  }
+
+  /**
+   * Get invited customer list (KEYED)
+   * GET `contract/private/affiliate/rebate-inviteUser`
+   * Feature: list entries include `accountAssetTotal` (exchange update 2026-04-07).
+   */
+  getFuturesAffiliateRebateInviteUser(
+    params: FuturesAffiliateRebateInviteUserRequest,
+  ): Promise<APIResponse<FuturesAffiliateRebateInviteUserResponse>> {
     return this.getPrivate(
       'contract/private/affiliate/rebate-inviteUser',
       params,

--- a/src/FuturesClientV2.ts
+++ b/src/FuturesClientV2.ts
@@ -16,10 +16,13 @@ import {
   FuturesAccountPlanOrdersRequest,
   FuturesAccountTradesRequest,
   FuturesAccountTransfersRequest,
+  FuturesAffiliateDepositWithdrawalListRequest,
   FuturesAffiliateRebateApiRequest,
   FuturesAffiliateRebatesRequest,
   FuturesAffiliateRebateUserRequest,
   FuturesAffiliateTradesRequest,
+  FuturesAutoRepaymentRequest,
+  FuturesCrossCollateralInterestLogRequest,
   FuturesKlinesRequest,
   FuturesSubTransfersRequest,
   FuturesSubWalletRequest,
@@ -51,10 +54,13 @@ import {
   FuturesAccountSubTransfer,
   FuturesAccountTrade,
   FuturesAccountTransfer,
+  FuturesAffiliateDepositWithdrawalListResult,
   FuturesAffiliateRebateApiResponse,
   FuturesAffiliateRebateUserResponse,
+  FuturesAutoRepaymentApiResponse,
   FuturesContractDepth,
   FuturesContractDetails,
+  FuturesCrossCollateralInterestLogApiResponse,
   FuturesFundingRate,
   FuturesFundingRateHistory,
   FuturesKline,
@@ -270,6 +276,27 @@ export class FuturesClientV2 extends BaseRestClient {
     params: FuturesAccountHistoricTransactionRequest,
   ): Promise<APIResponse<FuturesAccountHistoricTransaction[]>> {
     return this.getPrivate('contract/private/transaction-history', params);
+  }
+
+  /**
+   * Query auto repayment records (KEYED). Defaults to last 7 days if times omitted; max 20 records per request.
+   */
+  getFuturesAutoRepayment(
+    params?: FuturesAutoRepaymentRequest,
+  ): Promise<FuturesAutoRepaymentApiResponse> {
+    return this.getPrivate('contract/private/auto_repayment', params);
+  }
+
+  /**
+   * Query cross margin interest accrual logs (KEYED). Defaults to last 7 days; max interval 90 days; max 20 records per request.
+   */
+  getFuturesCrossCollateralInterestLog(
+    params?: FuturesCrossCollateralInterestLogRequest,
+  ): Promise<FuturesCrossCollateralInterestLogApiResponse> {
+    return this.getPrivate(
+      'contract/private/cross_collateral/interest_log',
+      params,
+    );
   }
 
   getFuturesTransfers(params: FuturesAccountTransfersRequest): Promise<
@@ -491,14 +518,17 @@ export class FuturesClientV2 extends BaseRestClient {
   }
 
   /**
-   * Get User Rebate Data (KEYED)
-   * Used for API affiliates to query contract rebate data within a certain time range
-   * Feature: Query up to 60 days of data
+   * Get invited customer list (KEYED)
+   * Used by agents to query rebate information of invited users within a specified time range.
+   * Feature: Query up to 60 days of data; list entries include `accountAssetTotal` (exchange update 2026-04-07).
    */
   getFuturesAffiliateRebateUser(
     params: FuturesAffiliateRebateUserRequest,
   ): Promise<APIResponse<FuturesAffiliateRebateUserResponse>> {
-    return this.getPrivate('contract/private/affiliate/rebate-user', params);
+    return this.getPrivate(
+      'contract/private/affiliate/rebate-inviteUser',
+      params,
+    );
   }
 
   /**
@@ -510,6 +540,19 @@ export class FuturesClientV2 extends BaseRestClient {
     params: FuturesAffiliateRebateApiRequest,
   ): Promise<APIResponse<FuturesAffiliateRebateApiResponse>> {
     return this.getPrivate('contract/private/affiliate/rebate-api', params);
+  }
+
+  /**
+   * Deposit and withdrawal information of invited users (KEYED)
+   * Feature: Query up to 60 days; max 50 records per page (exchange update 2026-04-07).
+   */
+  getFuturesAffiliateDepositWithdrawalList(
+    params: FuturesAffiliateDepositWithdrawalListRequest,
+  ): Promise<FuturesAffiliateDepositWithdrawalListResult> {
+    return this.getPrivate(
+      'contract/private/affiliate/deposit-withdrawal-list',
+      params,
+    );
   }
 
   /**

--- a/src/RestClient.ts
+++ b/src/RestClient.ts
@@ -29,12 +29,18 @@ import {
 } from './types/request/futures.types.js';
 import {
   AccountSubTransfersV1Request,
+  CancelAllSpotAlgoOrdersV4Request,
   CancelOrdersV3Request,
+  CancelSpotAlgoOrderV4Request,
   CancelSpotBatchOrdersV4Request,
   DepositWithdrawHistoryV2Request,
   MarginBorrowRecordsV1Request,
   MarginBorrowRepayV1Request,
   MarginRepayRecordsV1Request,
+  SpotAlgoHistoryOrdersV4Request,
+  SpotAlgoOpenOrdersV4Request,
+  SpotAlgoOrderByClientOrderIdV4Request,
+  SpotAlgoOrderByIdV4Request,
   SpotBrokerRebateRequest,
   SpotKlinesV1Request,
   SpotKlineV3Request,
@@ -45,6 +51,7 @@ import {
   SpotOrderTradeHistoryV4Request,
   SubmitMainTransferSubToSubV1Request,
   SubmitMarginTransferV1Request,
+  SubmitSpotAlgoOrderV4Request,
   SubmitSpotBatchOrdersV4Request,
   SubmitSpotOrderV2Request,
   SubmitSubTransferSubToMainV1Request,
@@ -94,6 +101,7 @@ import {
   MarginRepayRecordV1,
   ServiceStatus,
   SpotAccountTradeV4,
+  SpotAlgoOrderV4,
   SpotBrokerRebateResult,
   SpotCurrencyV1,
   SpotKlineV1,
@@ -509,6 +517,48 @@ export class RestClient extends BaseRestClient {
     recvWindow?: number;
   }): Promise<APIResponse<SpotAccountTradeV4[]>> {
     return this.postPrivate('spot/v4/query/order-trades', params);
+  }
+
+  submitSpotAlgoOrderV4(
+    params: SubmitSpotAlgoOrderV4Request,
+  ): Promise<APIResponse<{ order_id: string }>> {
+    return this.postPrivate('spot/v4/algo/submit_order', params);
+  }
+
+  cancelSpotAlgoOrderV4(
+    params: CancelSpotAlgoOrderV4Request,
+  ): Promise<APIResponse<{ result: boolean }>> {
+    return this.postPrivate('spot/v4/algo/cancel_order', params);
+  }
+
+  cancelAllSpotAlgoOrdersV4(
+    params: CancelAllSpotAlgoOrdersV4Request,
+  ): Promise<APIResponse<{}>> {
+    return this.postPrivate('spot/v4/algo/cancel_all', params);
+  }
+
+  getSpotAlgoOrderByIdV4(
+    params: SpotAlgoOrderByIdV4Request,
+  ): Promise<APIResponse<SpotAlgoOrderV4>> {
+    return this.postPrivate('spot/v4/query/algo/order', params);
+  }
+
+  getSpotAlgoOrderByClientOrderIdV4(
+    params: SpotAlgoOrderByClientOrderIdV4Request,
+  ): Promise<APIResponse<SpotAlgoOrderV4>> {
+    return this.postPrivate('spot/v4/query/algo/client-order', params);
+  }
+
+  getSpotAlgoOpenOrdersV4(
+    params?: SpotAlgoOpenOrdersV4Request,
+  ): Promise<APIResponse<SpotAlgoOrderV4[]>> {
+    return this.postPrivate('spot/v4/query/algo/open-orders', params);
+  }
+
+  getSpotAlgoHistoryOrdersV4(
+    params?: SpotAlgoHistoryOrdersV4Request,
+  ): Promise<APIResponse<SpotAlgoOrderV4[]>> {
+    return this.postPrivate('spot/v4/query/algo/history-orders', params);
   }
 
   /**

--- a/src/types/request/futures.types.ts
+++ b/src/types/request/futures.types.ts
@@ -233,7 +233,15 @@ export interface SubmitFuturesTrailOrderRequest {
   activation_price_type: 1 | 2;
 }
 
+/** GET `contract/private/affiliate/rebate-user` — single user rebate totals. */
 export interface FuturesAffiliateRebateUserRequest {
+  cid: number;
+  start_time: number;
+  end_time: number;
+}
+
+/** GET `contract/private/affiliate/rebate-inviteUser` — paginated invited customer list. */
+export interface FuturesAffiliateRebateInviteUserRequest {
   cid?: number;
   start_time: number;
   end_time: number;

--- a/src/types/request/futures.types.ts
+++ b/src/types/request/futures.types.ts
@@ -234,9 +234,38 @@ export interface SubmitFuturesTrailOrderRequest {
 }
 
 export interface FuturesAffiliateRebateUserRequest {
+  cid?: number;
+  start_time: number;
+  end_time: number;
+  page: number;
+  size: number;
+}
+
+/** Affiliate invited users deposit / withdrawal records (max 60 days, size max 50). */
+export interface FuturesAffiliateDepositWithdrawalListRequest {
+  page: number;
+  size: number;
+  type?: 1 | 2;
   cid: number;
   start_time: number;
   end_time: number;
+}
+
+export interface FuturesAutoRepaymentRequest {
+  start_time?: number;
+  end_time?: number;
+  page?: number;
+  size?: number;
+  from_coin_code?: string;
+  type?: string;
+}
+
+export interface FuturesCrossCollateralInterestLogRequest {
+  start_time?: number;
+  end_time?: number;
+  page?: number;
+  size?: number;
+  coin_code?: string;
 }
 
 export interface FuturesAffiliateRebateApiRequest {

--- a/src/types/request/spot.types.ts
+++ b/src/types/request/spot.types.ts
@@ -173,3 +173,57 @@ export interface SpotBrokerRebateRequest {
   start_time?: number;
   end_time?: number;
 }
+
+/** Spot algo order (v4): TP/SL or trigger. See `POST spot/v4/algo/submit_order`. */
+export interface SubmitSpotAlgoOrderV4Request {
+  symbol: string;
+  side: 'buy' | 'sell';
+  type: 'tp/sl' | 'trigger';
+  client_order_id?: string;
+  trigger_price?: string;
+  trigger_type?: 'limit' | 'market';
+  price?: string;
+  notional?: string;
+  size?: string;
+}
+
+export interface CancelSpotAlgoOrderV4Request {
+  symbol: string;
+  order_id: string;
+  type: 'tp/sl' | 'trigger';
+}
+
+export interface CancelAllSpotAlgoOrdersV4Request {
+  symbol?: string;
+  type: 'tp/sl' | 'trigger';
+}
+
+export interface SpotAlgoOrderByIdV4Request {
+  orderId: string;
+  queryState?: 'open' | 'history';
+  recvWindow?: number;
+}
+
+export interface SpotAlgoOrderByClientOrderIdV4Request {
+  clientOrderId: string;
+  queryState?: 'open' | 'history';
+  recvWindow?: number;
+}
+
+export interface SpotAlgoOpenOrdersV4Request {
+  symbol?: string;
+  orderMode?: 'trigger' | 'tp/sl';
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  recvWindow?: number;
+}
+
+export interface SpotAlgoHistoryOrdersV4Request {
+  symbol?: string;
+  orderMode?: 'trigger' | 'tp/sl';
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  recvWindow?: number;
+}

--- a/src/types/response/futures.types.ts
+++ b/src/types/response/futures.types.ts
@@ -314,11 +314,23 @@ export interface FuturesAffiliateRebateInviteUserRow {
 }
 
 /** `data` payload for GET `contract/private/affiliate/rebate-inviteUser`. */
-export interface FuturesAffiliateRebateUserResponse {
+export interface FuturesAffiliateRebateInviteUserResponse {
   list: FuturesAffiliateRebateInviteUserRow[];
   page: number;
   size: number;
   total: number;
+}
+
+/** `data` payload for GET `contract/private/affiliate/rebate-user` (single user). */
+export interface FuturesAffiliateRebateUserResponse {
+  cid: number;
+  back_rate: string;
+  trading_vol_total: string;
+  trading_fee_total: string;
+  rebate_total: string;
+  trading_vol: string;
+  trading_fee: string;
+  rebate: string;
 }
 
 export interface FuturesAffiliateDepositWithdrawalListItem {

--- a/src/types/response/futures.types.ts
+++ b/src/types/response/futures.types.ts
@@ -301,15 +301,86 @@ export interface FuturesAccountSubTransfer {
   submissionTime: number;
 }
 
-export interface FuturesAffiliateRebateUserResponse {
+/** Row from GET `contract/private/affiliate/rebate-inviteUser` (invite customer list). */
+export interface FuturesAffiliateRebateInviteUserRow {
+  rebateTotal: string;
+  tradingVolTotal: string;
+  cashbackRate: string;
+  tradingFeeTotal: string;
+  backRate: string;
   cid: number;
-  back_rate: string;
-  trading_vol_total: string;
-  trading_fee_total: string;
-  rebate_total: string;
-  trading_vol: string;
-  trading_fee: string;
-  rebate: string;
+  status: number;
+  accountAssetTotal: string;
+}
+
+/** `data` payload for GET `contract/private/affiliate/rebate-inviteUser`. */
+export interface FuturesAffiliateRebateUserResponse {
+  list: FuturesAffiliateRebateInviteUserRow[];
+  page: number;
+  size: number;
+  total: number;
+}
+
+export interface FuturesAffiliateDepositWithdrawalListItem {
+  dateTime: number;
+  cid: number;
+  remark: string;
+  parentCid: number;
+  userType: number;
+  type: number;
+  method: number;
+  amount: string;
+  coin: string;
+}
+
+export interface FuturesAffiliateDepositWithdrawalListResult {
+  total: number;
+  size: number;
+  page: number;
+  list: FuturesAffiliateDepositWithdrawalListItem[];
+}
+
+export interface FuturesAutoRepaymentRecord {
+  to_coin_code: string;
+  to_amount: string;
+  from_coin_code: string;
+  from_amount: string;
+  time: string;
+  type: string;
+  liquidation_fee: string;
+}
+
+export interface FuturesAutoRepaymentApiResponse {
+  errno: string;
+  message: string;
+  data: {
+    list: FuturesAutoRepaymentRecord[];
+    total: number;
+  };
+  success: boolean;
+}
+
+export interface FuturesCrossCollateralInterestLogItem {
+  id: number;
+  account_id: number;
+  coin_code: string;
+  rate: string;
+  interest: string;
+  liability: string;
+  interest_time: number;
+  created_at: string;
+  updated_at: string;
+  interest_free_amount: string;
+}
+
+export interface FuturesCrossCollateralInterestLogApiResponse {
+  errno: string;
+  message: string;
+  data: {
+    items: FuturesCrossCollateralInterestLogItem[];
+    total: number;
+  };
+  success: boolean;
 }
 
 export interface FuturesAffiliateRebateApiResponse {

--- a/src/types/response/spot.types.ts
+++ b/src/types/response/spot.types.ts
@@ -292,6 +292,25 @@ export interface SpotTradeBase {
   cancelSource: string;
 }
 
+/**
+ * Spot algo order (v4): trigger or TP/SL. Returned by algo query endpoints.
+ */
+export interface SpotAlgoOrderV4 {
+  orderId: string;
+  clientOrderId: string;
+  symbol: string;
+  side: OrderSide;
+  orderMode: string;
+  trigger_type: string;
+  state: string;
+  cancelSource: string;
+  price: string;
+  size: string;
+  notional: string;
+  createTime: number;
+  updateTime: number;
+}
+
 export interface SpotOrderV4 extends SpotTradeBase {
   state: string;
   priceAvg: string;


### PR DESCRIPTION
## Summary

SDK updates for BitMart **spot algo orders (v4)**, **futures V2** affiliate / cross-margin / auto-repayment APIs, **websocket** typing for private balance payloads, and **docs/examples** alignment.

---

## Spot — `RestClient` (REST)

**New (signed) endpoints**

| Method | Path |
|--------|------|
| `submitSpotAlgoOrderV4` | `POST spot/v4/algo/submit_order` |
| `cancelSpotAlgoOrderV4` | `POST spot/v4/algo/cancel_order` |
| `cancelAllSpotAlgoOrdersV4` | `POST spot/v4/algo/cancel_all` |
| `getSpotAlgoOrderByIdV4` | `POST spot/v4/query/algo/order` |
| `getSpotAlgoOrderByClientOrderIdV4` | `POST spot/v4/query/algo/client-order` |
| `getSpotAlgoOpenOrdersV4` | `POST spot/v4/query/algo/open-orders` |
| `getSpotAlgoHistoryOrdersV4` | `POST spot/v4/query/algo/history-orders` |

**Types**

- Request helpers in `src/types/request/spot.types.ts` (e.g. `SubmitSpotAlgoOrderV4Request`, algo query/open/history params).
- Response row type `SpotAlgoOrderV4` in `src/types/response/spot.types.ts`.

**WebSocket**

- `SpotPrivateBalanceUpdate` in `src/types/websockets/events.ts` — optional `account_type` (balance change source), per exchange update.
- Re-export: `src/index.ts` now exports `./types/websockets/events.js`.

**Docs & examples**

- `docs/endpointFunctionList.md` — new rows + refreshed `RestClient.ts` line links.
- `examples/apidoc/RestClient/` — one example per new method.

---

## Futures — `FuturesClientV2` (REST, `api-cloud-v2`)

**New**

| Method | Path |
|--------|------|
| `getFuturesAffiliateDepositWithdrawalList` | `GET contract/private/affiliate/deposit-withdrawal-list` |
| `getFuturesAutoRepayment` | `GET contract/private/auto_repayment` |
| `getFuturesCrossCollateralInterestLog` | `GET contract/private/cross_collateral/interest_log` |

**Changed (breaking)**

- `getFuturesAffiliateRebateUser` now calls **`contract/private/affiliate/rebate-inviteUser`** (replaces `rebate-user`).
- `FuturesAffiliateRebateUserRequest`: `cid` optional; **`page` and `size` required**; `start_time` / `end_time` unchanged (seconds).
- `FuturesAffiliateRebateUserResponse`: paginated `data` shape (`list`, `page`, `size`, `total`) with row type `FuturesAffiliateRebateInviteUserRow`, including **`accountAssetTotal`**.

**Types**

- New request/response interfaces in `src/types/request/futures.types.ts` and `src/types/response/futures.types.ts` (deposit/withdrawal list, auto repayment envelope, cross-collateral interest log envelope).

**Docs & examples**

- `docs/endpointFunctionList.md` — FuturesClientV2 table updated (new rows, `rebate-inviteUser`, line links).
- `examples/apidoc/FuturesClientV2/` — new/updated examples for affiliate deposit-withdrawal, invite user, auto repayment, interest log.

---

## Migration notes

- **Spot:** additive; no breaking changes to existing spot methods.
- **Futures affiliate invite user:** callers must use the new URL/params/response shape; any code assuming the old single-object `rebate-user` response needs updating.

---

## Checklist

- [x] `npm run build`
- [x] `npm run lint`