### PR TITLE
feat(v2.4.4): Add new Futures and Spot endpoints

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -49,116 +49,118 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L237) |  | GET | `system/time` |
-| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L241) |  | GET | `system/service` |
-| [getSpotCurrenciesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L251) |  | GET | `spot/v1/currencies` |
-| [getSpotTradingPairsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L257) |  | GET | `spot/v1/symbols` |
-| [getSpotTradingPairDetailsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L261) |  | GET | `spot/v1/symbols/details` |
-| [getSpotTickersV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L267) |  | GET | `spot/quotation/v3/tickers` |
-| [getSpotTickerV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L271) |  | GET | `spot/quotation/v3/ticker` |
-| [getSpotLatestKlineV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L277) |  | GET | `spot/quotation/v3/lite-klines` |
-| [getSpotHistoryKlineV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L283) |  | GET | `spot/quotation/v3/klines` |
-| [getSpotOrderBookDepthV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L289) |  | GET | `spot/quotation/v3/books` |
-| [getSpotRecentTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L296) |  | GET | `spot/quotation/v3/trades` |
-| [getSpotTickersV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L312) |  | GET | `spot/v2/ticker` |
-| [getSpotTickerV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L319) |  | GET | `spot/v1/ticker_detail` |
-| [getSpotKLineStepsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L328) |  | GET | `spot/v1/steps` |
-| [getSpotKlinesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L335) |  | GET | `spot/v1/symbols/kline` |
-| [getSpotOrderBookDepthV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L344) |  | GET | `spot/v1/symbols/book` |
-| [getAccountBalancesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L356) | :closed_lock_with_key:  | GET | `account/v1/wallet` |
-| [getAccountCurrenciesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L362) |  | GET | `account/v1/currencies` |
-| [getSpotWalletBalanceV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L368) | :closed_lock_with_key:  | GET | `spot/v1/wallet` |
-| [getAccountDepositAddressV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L374) | :closed_lock_with_key:  | GET | `account/v1/deposit/address` |
-| [getAccountWithdrawQuotaV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L380) | :closed_lock_with_key:  | GET | `account/v1/withdraw/charge` |
-| [submitWithdrawalV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L386) | :closed_lock_with_key:  | POST | `account/v1/withdraw/apply` |
-| [getWithdrawAddressList()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L392) | :closed_lock_with_key:  | GET | `account/v1/withdraw/address/list` |
-| [getDepositWithdrawHistoryV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L400) | :closed_lock_with_key:  | GET | `account/v2/deposit-withdraw/history` |
-| [getDepositWithdrawDetailV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L406) | :closed_lock_with_key:  | GET | `account/v1/deposit-withdraw/detail` |
-| [getMarginAccountDetailsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L412) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/account` |
-| [submitMarginAssetTransferV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L418) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/transfer` |
-| [getBasicSpotFeeRateV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L424) | :closed_lock_with_key:  | GET | `spot/v1/user_fee` |
-| [getActualSpotTradeFeeRateV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L428) | :closed_lock_with_key:  | GET | `spot/v1/trade_fee` |
-| [submitSpotOrderV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L440) | :closed_lock_with_key:  | POST | `spot/v2/submit_order` |
-| [submitMarginOrderV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L446) | :closed_lock_with_key:  | POST | `spot/v1/margin/submit_order` |
-| [submitSpotBatchOrdersV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L455) | :closed_lock_with_key:  | POST | `spot/v2/batch_orders` |
-| [cancelSpotOrderV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L461) | :closed_lock_with_key:  | POST | `spot/v3/cancel_order` |
-| [submitSpotBatchOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L467) | :closed_lock_with_key:  | POST | `spot/v4/batch_orders` |
-| [cancelSpotBatchOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L478) | :closed_lock_with_key:  | POST | `spot/v4/cancel_orders` |
-| [cancelAllSpotOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L484) | :closed_lock_with_key:  | POST | `spot/v4/cancel_all` |
-| [cancelSpotOrdersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L494) | :closed_lock_with_key:  | POST | `spot/v1/cancel_orders` |
-| [getSpotOrderByIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L504) | :closed_lock_with_key:  | POST | `spot/v4/query/order` |
-| [getSpotOrderByClientOrderIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L513) | :closed_lock_with_key:  | POST | `spot/v4/query/client-order` |
-| [getSpotOpenOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L519) | :closed_lock_with_key:  | POST | `spot/v4/query/open-orders` |
-| [getSpotHistoricOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L525) | :closed_lock_with_key:  | POST | `spot/v4/query/history-orders` |
-| [getSpotAccountTradesV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L534) | :closed_lock_with_key:  | POST | `spot/v4/query/trades` |
-| [getSpotAccountOrderTradesV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L543) | :closed_lock_with_key:  | POST | `spot/v4/query/order-trades` |
-| [submitSpotAlgoOrderV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L550) | :closed_lock_with_key:  | POST | `spot/v4/algo/submit_order` |
-| [cancelSpotAlgoOrderV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L556) | :closed_lock_with_key:  | POST | `spot/v4/algo/cancel_order` |
-| [cancelAllSpotAlgoOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L562) | :closed_lock_with_key:  | POST | `spot/v4/algo/cancel_all` |
-| [getSpotAlgoOrderByIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L568) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/order` |
-| [getSpotAlgoOrderByClientOrderIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L574) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/client-order` |
-| [getSpotAlgoOpenOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L580) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/open-orders` |
-| [getSpotAlgoHistoryOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L586) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/history-orders` |
-| [marginBorrowV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L598) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/borrow` |
-| [marginRepayV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L604) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/repay` |
-| [getMarginBorrowRecordV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L610) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/borrow_record` |
-| [getMarginRepayRecordV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L616) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/repay_record` |
-| [getMarginBorrowingRatesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L625) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/pairs` |
-| [submitMainTransferSubToMainV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L640) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/sub-to-main` |
-| [submitSubTransferSubToMainV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L649) | :closed_lock_with_key:  | POST | `account/sub-account/sub/v1/sub-to-main` |
-| [submitMainTransferMainToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L655) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/main-to-sub` |
-| [submitMainTransferSubToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L661) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/sub-to-sub` |
-| [submitSubTransferSubToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L667) | :closed_lock_with_key:  | POST | `account/sub-account/sub/v1/sub-to-sub` |
-| [getSubTransfersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L673) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/transfer-list` |
-| [getAccountSubTransfersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L679) | :closed_lock_with_key:  | GET | `account/sub-account/v1/transfer-history` |
-| [getSubSpotWalletBalancesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L685) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/wallet` |
-| [getSubAccountsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L691) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/subaccount-list` |
-| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L712) |  | GET | `contract/public/details` |
-| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L721) |  | GET | `contract/public/depth` |
-| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L730) |  | GET | `contract/public/open-interest` |
-| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L739) |  | GET | `contract/public/funding-rate` |
-| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L748) |  | GET | `contract/public/kline` |
-| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L763) | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
-| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L776) | :closed_lock_with_key:  | GET | `contract/private/order` |
-| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L785) | :closed_lock_with_key:  | GET | `contract/private/order-history` |
-| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L794) | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
-| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L803) | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
-| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L812) | :closed_lock_with_key:  | GET | `contract/private/position` |
-| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L821) | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
-| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L830) | :closed_lock_with_key:  | GET | `contract/private/trades` |
-| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L839) | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
-| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L850) | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
-| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L858) | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
-| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L867) | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
-| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L876) | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
-| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L887) | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
-| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L896) | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
-| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L905) | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
-| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L920) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/sub-to-main` |
-| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L932) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/main-to-sub` |
-| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L944) | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
-| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L956) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
-| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L970) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
-| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L982) | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
-| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1000) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
-| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1009) | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |
-| [getEarnAccountPosition()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1021) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/earn` |
-| [getFlexibleSavingProducts()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1025) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/product` |
-| [subscribeFlexibleSaving()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1031) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/subscribe` |
-| [redeemFlexibleSaving()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1037) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/redeem` |
-| [getFlexibleSavingPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1043) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/earn` |
-| [getFlexibleSavingHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1049) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/record` |
-| [getFixedSavingProducts()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1055) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/fixed/product` |
-| [subscribeFixedSaving()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1061) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/fixed/subscribe` |
-| [getFixedSavingPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1067) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/fixed/earn` |
-| [getFixedSavingHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1073) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/fixed/record` |
-| [redeemFixedSavingEarly()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1079) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/fixed/redeem` |
-| [updateFixedSavingAutoReinvest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1085) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/fixed/subscribe/operate` |
-| [setAutoSavingBatch()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1094) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/subscribe/batch/operate` |
-| [getAutoSavingBatchStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1103) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/subscribe/batch` |
-| [setFlexibleSavingAutoSubscribe()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1107) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/subscribe/operate` |
-| [getFlexibleSavingAutoSubscribeStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1116) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/subscribe/status` |
-| [getBrokerRebate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1128) | :closed_lock_with_key:  | GET | `spot/v1/broker/rebate` |
+| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L240) |  | GET | `system/time` |
+| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L244) |  | GET | `system/service` |
+| [getSpotCurrenciesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L254) |  | GET | `spot/v1/currencies` |
+| [getSpotTradingPairsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L260) |  | GET | `spot/v1/symbols` |
+| [getSpotTradingPairDetailsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L264) |  | GET | `spot/v1/symbols/details` |
+| [getSpotTickersV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L270) |  | GET | `spot/quotation/v3/tickers` |
+| [getSpotTickerV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L274) |  | GET | `spot/quotation/v3/ticker` |
+| [getSpotLatestKlineV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L280) |  | GET | `spot/quotation/v3/lite-klines` |
+| [getSpotHistoryKlineV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L286) |  | GET | `spot/quotation/v3/klines` |
+| [getSpotOrderBookDepthV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L292) |  | GET | `spot/quotation/v3/books` |
+| [getSpotRecentTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L299) |  | GET | `spot/quotation/v3/trades` |
+| [getSpotTickersV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L315) |  | GET | `spot/v2/ticker` |
+| [getSpotTickerV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L322) |  | GET | `spot/v1/ticker_detail` |
+| [getSpotKLineStepsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L331) |  | GET | `spot/v1/steps` |
+| [getSpotKlinesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L338) |  | GET | `spot/v1/symbols/kline` |
+| [getSpotOrderBookDepthV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L347) |  | GET | `spot/v1/symbols/book` |
+| [getAccountBalancesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L359) | :closed_lock_with_key:  | GET | `account/v1/wallet` |
+| [getAccountInfoV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L369) | :closed_lock_with_key:  | GET | `uapi-key/v1/account/info` |
+| [submitAccountTransferV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L377) | :closed_lock_with_key:  | POST | `account/v1/transfer` |
+| [getAccountCurrenciesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L383) |  | GET | `account/v1/currencies` |
+| [getSpotWalletBalanceV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L389) | :closed_lock_with_key:  | GET | `spot/v1/wallet` |
+| [getAccountDepositAddressV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L395) | :closed_lock_with_key:  | GET | `account/v1/deposit/address` |
+| [getAccountWithdrawQuotaV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L401) | :closed_lock_with_key:  | GET | `account/v1/withdraw/charge` |
+| [submitWithdrawalV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L407) | :closed_lock_with_key:  | POST | `account/v1/withdraw/apply` |
+| [getWithdrawAddressList()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L413) | :closed_lock_with_key:  | GET | `account/v1/withdraw/address/list` |
+| [getDepositWithdrawHistoryV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L421) | :closed_lock_with_key:  | GET | `account/v2/deposit-withdraw/history` |
+| [getDepositWithdrawDetailV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L427) | :closed_lock_with_key:  | GET | `account/v1/deposit-withdraw/detail` |
+| [getMarginAccountDetailsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L433) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/account` |
+| [submitMarginAssetTransferV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L439) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/transfer` |
+| [getBasicSpotFeeRateV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L445) | :closed_lock_with_key:  | GET | `spot/v1/user_fee` |
+| [getActualSpotTradeFeeRateV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L449) | :closed_lock_with_key:  | GET | `spot/v1/trade_fee` |
+| [submitSpotOrderV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L461) | :closed_lock_with_key:  | POST | `spot/v2/submit_order` |
+| [submitMarginOrderV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L467) | :closed_lock_with_key:  | POST | `spot/v1/margin/submit_order` |
+| [submitSpotBatchOrdersV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L476) | :closed_lock_with_key:  | POST | `spot/v2/batch_orders` |
+| [cancelSpotOrderV3()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L482) | :closed_lock_with_key:  | POST | `spot/v3/cancel_order` |
+| [submitSpotBatchOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L488) | :closed_lock_with_key:  | POST | `spot/v4/batch_orders` |
+| [cancelSpotBatchOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L499) | :closed_lock_with_key:  | POST | `spot/v4/cancel_orders` |
+| [cancelAllSpotOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L505) | :closed_lock_with_key:  | POST | `spot/v4/cancel_all` |
+| [cancelSpotOrdersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L515) | :closed_lock_with_key:  | POST | `spot/v1/cancel_orders` |
+| [getSpotOrderByIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L525) | :closed_lock_with_key:  | POST | `spot/v4/query/order` |
+| [getSpotOrderByClientOrderIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L534) | :closed_lock_with_key:  | POST | `spot/v4/query/client-order` |
+| [getSpotOpenOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L540) | :closed_lock_with_key:  | POST | `spot/v4/query/open-orders` |
+| [getSpotHistoricOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L546) | :closed_lock_with_key:  | POST | `spot/v4/query/history-orders` |
+| [getSpotAccountTradesV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L555) | :closed_lock_with_key:  | POST | `spot/v4/query/trades` |
+| [getSpotAccountOrderTradesV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L564) | :closed_lock_with_key:  | POST | `spot/v4/query/order-trades` |
+| [submitSpotAlgoOrderV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L571) | :closed_lock_with_key:  | POST | `spot/v4/algo/submit_order` |
+| [cancelSpotAlgoOrderV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L577) | :closed_lock_with_key:  | POST | `spot/v4/algo/cancel_order` |
+| [cancelAllSpotAlgoOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L583) | :closed_lock_with_key:  | POST | `spot/v4/algo/cancel_all` |
+| [getSpotAlgoOrderByIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L589) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/order` |
+| [getSpotAlgoOrderByClientOrderIdV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L595) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/client-order` |
+| [getSpotAlgoOpenOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L601) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/open-orders` |
+| [getSpotAlgoHistoryOrdersV4()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L607) | :closed_lock_with_key:  | POST | `spot/v4/query/algo/history-orders` |
+| [marginBorrowV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L619) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/borrow` |
+| [marginRepayV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L625) | :closed_lock_with_key:  | POST | `spot/v1/margin/isolated/repay` |
+| [getMarginBorrowRecordV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L631) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/borrow_record` |
+| [getMarginRepayRecordV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L637) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/repay_record` |
+| [getMarginBorrowingRatesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L646) | :closed_lock_with_key:  | GET | `spot/v1/margin/isolated/pairs` |
+| [submitMainTransferSubToMainV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L661) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/sub-to-main` |
+| [submitSubTransferSubToMainV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L670) | :closed_lock_with_key:  | POST | `account/sub-account/sub/v1/sub-to-main` |
+| [submitMainTransferMainToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L676) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/main-to-sub` |
+| [submitMainTransferSubToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L682) | :closed_lock_with_key:  | POST | `account/sub-account/main/v1/sub-to-sub` |
+| [submitSubTransferSubToSubV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L688) | :closed_lock_with_key:  | POST | `account/sub-account/sub/v1/sub-to-sub` |
+| [getSubTransfersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L694) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/transfer-list` |
+| [getAccountSubTransfersV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L700) | :closed_lock_with_key:  | GET | `account/sub-account/v1/transfer-history` |
+| [getSubSpotWalletBalancesV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L706) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/wallet` |
+| [getSubAccountsV1()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L712) | :closed_lock_with_key:  | GET | `account/sub-account/main/v1/subaccount-list` |
+| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L733) |  | GET | `contract/public/details` |
+| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L742) |  | GET | `contract/public/depth` |
+| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L751) |  | GET | `contract/public/open-interest` |
+| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L760) |  | GET | `contract/public/funding-rate` |
+| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L769) |  | GET | `contract/public/kline` |
+| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L784) | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
+| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L797) | :closed_lock_with_key:  | GET | `contract/private/order` |
+| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L806) | :closed_lock_with_key:  | GET | `contract/private/order-history` |
+| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L815) | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
+| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L824) | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
+| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L833) | :closed_lock_with_key:  | GET | `contract/private/position` |
+| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L842) | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
+| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L851) | :closed_lock_with_key:  | GET | `contract/private/trades` |
+| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L860) | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
+| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L871) | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
+| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L879) | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
+| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L888) | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
+| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L897) | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
+| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L908) | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
+| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L917) | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
+| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L926) | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
+| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L941) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/sub-to-main` |
+| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L953) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/main-to-sub` |
+| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L965) | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
+| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L977) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
+| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L991) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
+| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1003) | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
+| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1021) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
+| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1030) | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |
+| [getEarnAccountPosition()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1042) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/earn` |
+| [getFlexibleSavingProducts()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1046) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/product` |
+| [subscribeFlexibleSaving()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1052) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/subscribe` |
+| [redeemFlexibleSaving()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1058) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/redeem` |
+| [getFlexibleSavingPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1064) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/earn` |
+| [getFlexibleSavingHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1070) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/record` |
+| [getFixedSavingProducts()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1076) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/fixed/product` |
+| [subscribeFixedSaving()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1082) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/fixed/subscribe` |
+| [getFixedSavingPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1088) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/fixed/earn` |
+| [getFixedSavingHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1094) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/fixed/record` |
+| [redeemFixedSavingEarly()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1100) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/fixed/redeem` |
+| [updateFixedSavingAutoReinvest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1106) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/fixed/subscribe/operate` |
+| [setAutoSavingBatch()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1115) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/subscribe/batch/operate` |
+| [getAutoSavingBatchStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1124) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/subscribe/batch` |
+| [setFlexibleSavingAutoSubscribe()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1128) | :closed_lock_with_key:  | POST | `newearn/cloud/v1/saving/subscribe/operate` |
+| [getFlexibleSavingAutoSubscribeStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1137) | :closed_lock_with_key:  | GET | `newearn/cloud/v1/saving/subscribe/status` |
+| [getBrokerRebate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/RestClient.ts#L1149) | :closed_lock_with_key:  | GET | `spot/v1/broker/rebate` |
 
 # FuturesClientV2.ts
 
@@ -166,60 +168,63 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L109) |  | GET | `system/time` |
-| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L113) |  | GET | `system/service` |
-| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L134) |  | GET | `contract/public/details` |
-| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L140) |  | GET | `contract/public/depth` |
-| [getFuturesMarketTrade()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L146) |  | GET | `contract/public/market-trade` |
-| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L153) |  | GET | `contract/public/open-interest` |
-| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L159) |  | GET | `contract/public/funding-rate` |
-| [getFuturesFundingRateV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L169) |  | GET | `contract/public/funding-rate-v2` |
-| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L175) |  | GET | `contract/public/kline` |
-| [getFuturesMarkPriceKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L181) |  | GET | `contract/public/markprice-kline` |
-| [getFuturesFundingRateHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L187) |  | GET | `contract/public/funding-rate-history` |
-| [getFuturesLeverageBracket()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L203) |  | GET | `contract/public/leverage-bracket` |
-| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L217) | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
-| [getFuturesTradeFeeRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L227) | :closed_lock_with_key:  | GET | `contract/private/trade-fee-rate` |
-| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L237) | :closed_lock_with_key:  | GET | `contract/private/order` |
-| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L243) | :closed_lock_with_key:  | GET | `contract/private/order-history` |
-| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L249) | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
-| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L255) | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
-| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L261) | :closed_lock_with_key:  | GET | `contract/private/position` |
-| [getFuturesAccountPositionsV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L268) | :closed_lock_with_key:  | GET | `contract/private/position-v2` |
-| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L278) | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
-| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L285) | :closed_lock_with_key:  | GET | `contract/private/trades` |
-| [getFuturesAccountTransactionHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L291) | :closed_lock_with_key:  | GET | `contract/private/transaction-history` |
-| [getFuturesAutoRepayment()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L300) | :closed_lock_with_key:  | GET | `contract/private/auto_repayment` |
-| [getFuturesCrossCollateralInterestLog()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L309) | :closed_lock_with_key:  | GET | `contract/private/cross_collateral/interest_log` |
-| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L318) | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
-| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L326) | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
-| [updateFuturesLimitOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L332) | :closed_lock_with_key:  | POST | `contract/private/modify-limit-order` |
-| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L341) | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
-| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L347) | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
-| [cancelAllFuturesOrdersAfter()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L353) | :closed_lock_with_key:  | POST | `contract/private/cancel-all-after` |
-| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L360) | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
-| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L368) | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
-| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L374) | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
-| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L380) | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
-| [submitFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L386) | :closed_lock_with_key:  | POST | `contract/private/submit-tp-sl-order` |
-| [updateFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L395) | :closed_lock_with_key:  | POST | `contract/private/modify-plan-order` |
-| [updateFuturesPresetPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L403) | :closed_lock_with_key:  | POST | `contract/private/modify-preset-plan-order` |
-| [updateFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L416) | :closed_lock_with_key:  | POST | `contract/private/modify-tp-sl-order` |
-| [submitFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L424) | :closed_lock_with_key:  | POST | `contract/private/submit-trail-order` |
-| [cancelFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L432) | :closed_lock_with_key:  | POST | `contract/private/cancel-trail-order` |
-| [setPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L441) | :closed_lock_with_key:  | POST | `contract/private/set-position-mode` |
-| [getPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L450) | :closed_lock_with_key:  | GET | `contract/private/get-position-mode` |
-| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L462) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/sub-to-main` |
-| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L471) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/main-to-sub` |
-| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L480) | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
-| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L489) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
-| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L500) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
-| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L509) | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
-| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L524) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
-| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L530) | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |
-| [getFuturesAffiliateRebateUser()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L540) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-user` |
-| [getFuturesAffiliateCustomerInfo()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L550) | :closed_lock_with_key:  | GET | `contract/private/affiliate/aff-customer-info` |
-| [getFuturesAffiliateRebateInviteUser()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L564) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-inviteUser` |
-| [getFuturesAffiliateRebateApi()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L578) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-api` |
-| [getFuturesAffiliateDepositWithdrawalList()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L588) | :closed_lock_with_key:  | GET | `contract/private/affiliate/deposit-withdrawal-list` |
-| [submitFuturesSimulatedClaim()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L613) | :closed_lock_with_key:  | POST | `contract/private/claim` |
+| [getSystemTime()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L113) |  | GET | `system/time` |
+| [getSystemStatus()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L117) |  | GET | `system/service` |
+| [getFuturesContractDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L138) |  | GET | `contract/public/details` |
+| [getFuturesContractDepth()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L144) |  | GET | `contract/public/depth` |
+| [getFuturesMarketTrade()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L150) |  | GET | `contract/public/market-trade` |
+| [getFuturesOpenInterest()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L157) |  | GET | `contract/public/open-interest` |
+| [getFuturesFundingRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L163) |  | GET | `contract/public/funding-rate` |
+| [getFuturesFundingRateV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L173) |  | GET | `contract/public/funding-rate-v2` |
+| [getFuturesKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L179) |  | GET | `contract/public/kline` |
+| [getFuturesMarkPriceKlines()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L185) |  | GET | `contract/public/markprice-kline` |
+| [getFuturesFundingRateHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L191) |  | GET | `contract/public/funding-rate-history` |
+| [getFuturesLeverageBracket()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L207) |  | GET | `contract/public/leverage-bracket` |
+| [getFuturesAccountAssets()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L221) | :closed_lock_with_key:  | GET | `contract/private/assets-detail` |
+| [getFuturesTradeFeeRate()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L231) | :closed_lock_with_key:  | GET | `contract/private/trade-fee-rate` |
+| [getFuturesAccountOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L241) | :closed_lock_with_key:  | GET | `contract/private/order` |
+| [getFuturesAccountOrderHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L247) | :closed_lock_with_key:  | GET | `contract/private/order-history` |
+| [getFuturesAccountOpenOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L253) | :closed_lock_with_key:  | GET | `contract/private/get-open-orders` |
+| [getFuturesAccountPlanOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L259) | :closed_lock_with_key:  | GET | `contract/private/current-plan-order` |
+| [getFuturesAccountPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L265) | :closed_lock_with_key:  | GET | `contract/private/position` |
+| [getFuturesAccountPositionsV2()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L272) | :closed_lock_with_key:  | GET | `contract/private/position-v2` |
+| [getPositionRiskDetails()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L282) | :closed_lock_with_key:  | GET | `contract/private/position-risk` |
+| [getFuturesAccountTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L289) | :closed_lock_with_key:  | GET | `contract/private/trades` |
+| [getFuturesAccountTransactionHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L295) | :closed_lock_with_key:  | GET | `contract/private/transaction-history` |
+| [getFuturesAutoRepayment()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L304) | :closed_lock_with_key:  | GET | `contract/private/auto_repayment` |
+| [getFuturesCrossCollateralInterestLog()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L313) | :closed_lock_with_key:  | GET | `contract/private/cross_collateral/interest_log` |
+| [getFuturesTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L322) | :closed_lock_with_key:  | GET | `account/v1/transfer-contract-list` |
+| [submitFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L330) | :closed_lock_with_key:  | POST | `contract/private/submit-order` |
+| [updateFuturesLimitOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L336) | :closed_lock_with_key:  | POST | `contract/private/modify-limit-order` |
+| [cancelFuturesOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L345) | :closed_lock_with_key:  | POST | `contract/private/cancel-order` |
+| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L351) | :closed_lock_with_key:  | POST | `contract/private/cancel-orders` |
+| [cancelAllFuturesOrdersAfter()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L357) | :closed_lock_with_key:  | POST | `contract/private/cancel-all-after` |
+| [closeAllFuturesPositions()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L368) | :closed_lock_with_key:  | POST | `contract/private/close-all-position` |
+| [submitFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L374) | :closed_lock_with_key:  | POST | `contract/private/submit-plan-order` |
+| [cancelFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L382) | :closed_lock_with_key:  | POST | `contract/private/cancel-plan-order` |
+| [submitFuturesTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L388) | :closed_lock_with_key:  | POST | `account/v1/transfer-contract` |
+| [submitFuturesFundingAccountTransfer()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L398) | :closed_lock_with_key:  | POST | `contract/private/account/v1/transfer` |
+| [setFuturesLeverage()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L404) | :closed_lock_with_key:  | POST | `contract/private/submit-leverage` |
+| [submitFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L410) | :closed_lock_with_key:  | POST | `contract/private/submit-tp-sl-order` |
+| [updateFuturesPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L419) | :closed_lock_with_key:  | POST | `contract/private/modify-plan-order` |
+| [updateFuturesPresetPlanOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L427) | :closed_lock_with_key:  | POST | `contract/private/modify-preset-plan-order` |
+| [updateFuturesTPSLOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L440) | :closed_lock_with_key:  | POST | `contract/private/modify-tp-sl-order` |
+| [submitFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L448) | :closed_lock_with_key:  | POST | `contract/private/submit-trail-order` |
+| [cancelFuturesTrailOrder()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L456) | :closed_lock_with_key:  | POST | `contract/private/cancel-trail-order` |
+| [setPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L465) | :closed_lock_with_key:  | POST | `contract/private/set-position-mode` |
+| [getPositionMode()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L474) | :closed_lock_with_key:  | GET | `contract/private/get-position-mode` |
+| [submitFuturesSubToMainTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L486) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/sub-to-main` |
+| [submitFuturesMainToSubTransferFromMain()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L495) | :closed_lock_with_key:  | POST | `account/contract/sub-account/main/v1/main-to-sub` |
+| [submitFuturesSubToMainSubFromSub()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L504) | :closed_lock_with_key:  | POST | `account/contract/sub-account/sub/v1/sub-to-main` |
+| [getFuturesSubWallet()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L513) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/wallet` |
+| [getFuturesSubTransfers()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L524) | :closed_lock_with_key:  | GET | `account/contract/sub-account/main/v1/transfer-list` |
+| [getFuturesSubTransferHistory()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L533) | :closed_lock_with_key:  | GET | `account/contract/sub-account/v1/transfer-history` |
+| [getFuturesAffiliateRebates()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L548) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-list` |
+| [getFuturesAffiliateTrades()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L554) | :closed_lock_with_key:  | GET | `contract/private/affiliate/trade-list` |
+| [getFuturesAffiliateRebateUser()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L564) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-user` |
+| [getFuturesAffiliateInviteCheck()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L574) | :closed_lock_with_key:  | GET | `contract/private/affiliate/invite-check` |
+| [getFuturesAffiliateCustomerInfo()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L584) | :closed_lock_with_key:  | GET | `contract/private/affiliate/aff-customer-info` |
+| [getFuturesAffiliateRebateInviteUser()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L598) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-inviteUser` |
+| [getFuturesAffiliateRebateApi()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L612) | :closed_lock_with_key:  | GET | `contract/private/affiliate/rebate-api` |
+| [getFuturesAffiliateDepositWithdrawalList()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L622) | :closed_lock_with_key:  | GET | `contract/private/affiliate/deposit-withdrawal-list` |
+| [submitFuturesSimulatedClaim()](https://github.com/tiagosiebler/bitmart-api/blob/master/src/FuturesClientV2.ts#L647) | :closed_lock_with_key:  | POST | `contract/private/claim` |

--- a/examples/apidoc/FuturesClientV2/closeAllFuturesPositions.js
+++ b/examples/apidoc/FuturesClientV2/closeAllFuturesPositions.js
@@ -1,0 +1,23 @@
+import { FuturesClientV2 } from 'bitmart-api';
+// or, if require is preferred:
+// const { FuturesClientV2 } = require('bitmart-api');
+
+// This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
+// This bitmart API SDK is available on npm via "npm install bitmart-api"
+// ENDPOINT: contract/private/close-all-position
+// METHOD: POST
+// PUBLIC: NO
+
+const client = new FuturesClientV2({
+  apiKey: 'yourAPIKeyHere',
+  apiSecret: 'yourAPISecretHere',
+  apiMemo: 'yourAPIMemoHere',
+});
+
+client.closeAllFuturesPositions(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/FuturesClientV2/getFuturesAffiliateInviteCheck.js
+++ b/examples/apidoc/FuturesClientV2/getFuturesAffiliateInviteCheck.js
@@ -1,0 +1,23 @@
+import { FuturesClientV2 } from 'bitmart-api';
+// or, if require is preferred:
+// const { FuturesClientV2 } = require('bitmart-api');
+
+// This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
+// This bitmart API SDK is available on npm via "npm install bitmart-api"
+// ENDPOINT: contract/private/affiliate/invite-check
+// METHOD: GET
+// PUBLIC: NO
+
+const client = new FuturesClientV2({
+  apiKey: 'yourAPIKeyHere',
+  apiSecret: 'yourAPISecretHere',
+  apiMemo: 'yourAPIMemoHere',
+});
+
+client.getFuturesAffiliateInviteCheck(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/FuturesClientV2/submitFuturesFundingAccountTransfer.js
+++ b/examples/apidoc/FuturesClientV2/submitFuturesFundingAccountTransfer.js
@@ -1,0 +1,23 @@
+import { FuturesClientV2 } from 'bitmart-api';
+// or, if require is preferred:
+// const { FuturesClientV2 } = require('bitmart-api');
+
+// This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
+// This bitmart API SDK is available on npm via "npm install bitmart-api"
+// ENDPOINT: contract/private/account/v1/transfer
+// METHOD: POST
+// PUBLIC: NO
+
+const client = new FuturesClientV2({
+  apiKey: 'yourAPIKeyHere',
+  apiSecret: 'yourAPISecretHere',
+  apiMemo: 'yourAPIMemoHere',
+});
+
+client.submitFuturesFundingAccountTransfer(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClient/getAccountInfoV1.js
+++ b/examples/apidoc/RestClient/getAccountInfoV1.js
@@ -1,0 +1,23 @@
+import { RestClient } from 'bitmart-api';
+// or, if require is preferred:
+// const { RestClient } = require('bitmart-api');
+
+// This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
+// This bitmart API SDK is available on npm via "npm install bitmart-api"
+// ENDPOINT: uapi-key/v1/account/info
+// METHOD: GET
+// PUBLIC: NO
+
+const client = new RestClient({
+  apiKey: 'yourAPIKeyHere',
+  apiSecret: 'yourAPISecretHere',
+  apiMemo: 'yourAPIMemoHere',
+});
+
+client.getAccountInfoV1(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClient/submitAccountTransferV1.js
+++ b/examples/apidoc/RestClient/submitAccountTransferV1.js
@@ -1,0 +1,23 @@
+import { RestClient } from 'bitmart-api';
+// or, if require is preferred:
+// const { RestClient } = require('bitmart-api');
+
+// This example shows how to call this bitmart API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitmart-api" for bitmart exchange
+// This bitmart API SDK is available on npm via "npm install bitmart-api"
+// ENDPOINT: account/v1/transfer
+// METHOD: POST
+// PUBLIC: NO
+
+const client = new RestClient({
+  apiKey: 'yourAPIKeyHere',
+  apiSecret: 'yourAPISecretHere',
+  apiMemo: 'yourAPIMemoHere',
+});
+
+client.submitAccountTransferV1(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/llms.txt
+++ b/llms.txt
@@ -181,6 +181,9 @@ export interface AccountCurrencyBalanceV1 {
   available: string;
   available_usd_valuation: string;
   frozen: string;
+  unAvailable?: string;
+  fundAvailable?: string;
+  fundFroze?: string;
 }
 
 ================
@@ -191,6 +194,36 @@ export interface WsDataEvent<TData = any, TWSKey = string> {
   table: string;
   wsKey: TWSKey;
 }
+⋮----
+/** `spot/bookTicker:{symbol}` public best bid/ask stream (exchange update 2026-03-25). */
+export interface SpotBookTickerEvent {
+  symbol: string;
+  bid_px: string;
+  bid_sz: string;
+  ask_px: string;
+  ask_sz: string;
+  ts: string;
+}
+⋮----
+/** `spot/user/balance:BALANCE_UPDATE` balance change payload. */
+export interface SpotBalanceUpdateEvent {
+  event_type:
+    | 'TRANSACTION_COMPLETED'
+    | 'ACCOUNT_RECHARGE'
+    | 'ACCOUNT_WITHDRAWAL'
+    | 'ACCOUNT_TRANSFER'
+    | 'BMX_DEDUCTION';
+  /** Balance change source account type (exchange update 2026-03-19). */
+  account_type?: 'BITMART' | 'COPPER' | 'COBO';
+  event_time: string;
+  balance_details: {
+    ccy: string;
+    av_bal: string;
+    fz_bal: string;
+  }[];
+}
+⋮----
+/** Balance change source account type (exchange update 2026-03-19). */
 
 ================
 File: src/types/websockets/requests.ts
@@ -508,109 +541,6 @@ export type DefaultLogger = typeof DefaultLogger;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 ⋮----
 // console.log(_params);
-
-================
-File: src/types/request/earn.types.ts
-================
-export interface EarnFlexibleProductListRequest {
-  coinName?: string;
-  currentPage: number;
-  sizePage: number;
-}
-⋮----
-export interface EarnFlexibleSubscribeRequest {
-  productId: string;
-  amount: string;
-  /** Unique request key, 20 digits (0-9 only) */
-  requestNo: string;
-}
-⋮----
-/** Unique request key, 20 digits (0-9 only) */
-⋮----
-export interface EarnFlexibleRedeemRequest {
-  earnId: string;
-  amount: string;
-  requestNo: string;
-}
-⋮----
-export interface EarnFlexiblePositionsRequest {
-  coinName?: string;
-  productId?: string;
-  currentPage: number;
-  sizePage: number;
-}
-⋮----
-export type EarnFlexibleRecordType = 'subscribe' | 'redeem' | 'interest';
-⋮----
-export interface EarnFlexibleHistoryRequest {
-  type: EarnFlexibleRecordType;
-  startTime?: number;
-  endTime?: number;
-  coinName?: string;
-  currentPage: number;
-  sizePage: number;
-}
-⋮----
-export interface EarnFixedProductListRequest {
-  coinName?: string;
-  currentPage: number;
-  sizePage: number;
-}
-⋮----
-export type EarnFixedAutoSubscribeAction =
-  | 'OFF'
-  | 'REINVEST_FLEXIBLE'
-  | 'REINVEST_FIXED';
-⋮----
-export interface EarnFixedSubscribeRequest {
-  productId: string;
-  amount: string;
-  requestNo: string;
-  autoSubscribe: EarnFixedAutoSubscribeAction;
-}
-⋮----
-export interface EarnFixedPositionsRequest {
-  coinName?: string;
-  productId?: string;
-  currentPage: number;
-  sizePage: number;
-}
-⋮----
-export type EarnFixedRecordType = 'subscribe' | 'redeem' | 'interest';
-⋮----
-export interface EarnFixedHistoryRequest {
-  type: EarnFixedRecordType;
-  startTime?: number;
-  endTime?: number;
-  coinName?: string;
-  currentPage: number;
-  sizePage: number;
-}
-⋮----
-export interface EarnFixedEarlyRedeemRequest {
-  earnId: string;
-  requestNo: string;
-}
-⋮----
-export interface EarnFixedAutoReinvestUpdateRequest {
-  earnId: string;
-  autoSubscribe: EarnFixedAutoSubscribeAction;
-}
-⋮----
-export type EarnAutoSavingBatchAction = 'open' | 'close';
-⋮----
-export interface EarnAutoSavingBatchOperateRequest {
-  autoSubscribe: EarnAutoSavingBatchAction;
-}
-⋮----
-export interface EarnFlexibleAutoSubscribeOperateRequest {
-  productId: string;
-  autoSubscribe: EarnAutoSavingBatchAction;
-}
-⋮----
-export interface EarnFlexibleAutoSubscribeStatusRequest {
-  productId: string;
-}
 
 ================
 File: src/types/response/earn.types.ts
@@ -1308,6 +1238,109 @@ export async function signMessage(
 export function checkWebCryptoAPISupported()
 
 ================
+File: src/types/request/earn.types.ts
+================
+export interface EarnFlexibleProductListRequest {
+  coinName?: string;
+  currentPage: number;
+  sizePage: number;
+}
+⋮----
+export interface EarnFlexibleSubscribeRequest {
+  productId: string;
+  amount: string;
+  /** Unique request key, 20 digits (0-9 only) */
+  requestNo: string;
+}
+⋮----
+/** Unique request key, 20 digits (0-9 only) */
+⋮----
+export interface EarnFlexibleRedeemRequest {
+  earnId: string;
+  amount: string;
+  requestNo: string;
+}
+⋮----
+export interface EarnFlexiblePositionsRequest {
+  coinName?: string;
+  productId?: string;
+  currentPage: number;
+  sizePage: number;
+}
+⋮----
+export type EarnFlexibleRecordType = 'subscribe' | 'redeem' | 'interest';
+⋮----
+export interface EarnFlexibleHistoryRequest {
+  type: EarnFlexibleRecordType;
+  startTime?: number;
+  endTime?: number;
+  coinName?: string;
+  currentPage: number;
+  sizePage: number;
+}
+⋮----
+export interface EarnFixedProductListRequest {
+  coinName?: string;
+  currentPage: number;
+  sizePage: number;
+}
+⋮----
+export type EarnFixedAutoSubscribeAction =
+  | 'OFF'
+  | 'REINVEST_FLEXIBLE'
+  | 'REINVEST_FIXED';
+⋮----
+export interface EarnFixedSubscribeRequest {
+  productId: string;
+  amount: string;
+  requestNo: string;
+  autoSubscribe: EarnFixedAutoSubscribeAction;
+}
+⋮----
+export interface EarnFixedPositionsRequest {
+  coinName?: string;
+  productId?: string;
+  currentPage: number;
+  sizePage: number;
+}
+⋮----
+export type EarnFixedRecordType = 'subscribe' | 'redeem' | 'interest';
+⋮----
+export interface EarnFixedHistoryRequest {
+  type: EarnFixedRecordType;
+  startTime?: number;
+  endTime?: number;
+  coinName?: string;
+  currentPage: number;
+  sizePage: number;
+}
+⋮----
+export interface EarnFixedEarlyRedeemRequest {
+  earnId: string;
+  requestNo: string;
+}
+⋮----
+export interface EarnFixedAutoReinvestUpdateRequest {
+  earnId: string;
+  autoSubscribe: EarnFixedAutoSubscribeAction;
+}
+⋮----
+export type EarnAutoSavingBatchAction = 'open' | 'close';
+⋮----
+export interface EarnAutoSavingBatchOperateRequest {
+  autoSubscribe: EarnAutoSavingBatchAction;
+}
+⋮----
+export interface EarnFlexibleAutoSubscribeOperateRequest {
+  productId: string;
+  autoSubscribe: EarnAutoSavingBatchAction;
+}
+⋮----
+export interface EarnFlexibleAutoSubscribeStatusRequest {
+  productId: string;
+}
+
+================
 File: src/types/request/spot.types.ts
 ================
 export interface SpotKlineV3Request {
@@ -1331,12 +1364,25 @@ export interface SpotOrderBookDepthV1Request {
   size?: number;
 }
 ⋮----
+export interface AccountBalancesV1Request {
+  currency?: string;
+  needUsdValuation?: boolean;
+  sourceAccount?: 'SPOT' | 'FUND';
+}
+⋮----
+export interface SubmitAccountTransferV1Request {
+  currency?: string;
+  amount?: string;
+  type?: 'spot_to_fund' | 'fund_to_spot';
+}
+⋮----
 export interface SubmitWithdrawalV1Request {
   currency: string;
   amount: string;
   destination: 'To Digital Address';
   address: string;
   address_memo?: string;
+  sourceAccount?: 'SPOT' | 'FUND';
 }
 ⋮----
 export interface DepositWithdrawHistoryV2Request {
@@ -2001,6 +2047,39 @@ export interface SpotBrokerRebateResult {
     [date: string]: SpotBrokerRebateRow[];
   };
 }
+⋮----
+/** GET `uapi-key/v1/account/info` — API key row in account info response. */
+export interface AccountApiKeyInfoV1 {
+  access_key_masked: string;
+  is_current: boolean;
+  permissions: string[];
+  ip_whitelist: string[];
+  api_key_label: string;
+  api_key_created_time: number;
+  api_key_expire_time: number;
+  api_key_status: 'active' | 'frozen' | 'expired';
+}
+⋮----
+/** GET `uapi-key/v1/account/info` — account KYC and API key metadata. */
+export interface AccountInfoV1 {
+  cid: string;
+  account_type: 'main' | 'sub';
+  parent_cid: string | null;
+  account_status: 'active' | 'frozen';
+  kyc_level: string;
+  register_time: number;
+  broker_id: string;
+  api_keys: AccountApiKeyInfoV1[];
+}
+⋮----
+/** Non-standard wrapper used by `uapi-key/v1/account/info`. */
+export interface UapiKeyAccountInfoResponse {
+  code: number;
+  msg: string;
+  data: AccountInfoV1;
+  errorData: unknown;
+  success: boolean;
+}
 
 ================
 File: .eslintrc.cjs
@@ -2430,6 +2509,7 @@ import {
   TransferFuturesAssetsRequest,
 } from './types/request/futures.types.js';
 import {
+  AccountBalancesV1Request,
   AccountSubTransfersV1Request,
   CancelAllSpotAlgoOrdersV4Request,
   CancelOrdersV3Request,
@@ -2451,6 +2531,7 @@ import {
   SpotOrderByClientOrderIdV4Request,
   SpotOrderByIdV4Request,
   SpotOrderTradeHistoryV4Request,
+  SubmitAccountTransferV1Request,
   SubmitMainTransferSubToSubV1Request,
   SubmitMarginTransferV1Request,
   SubmitSpotAlgoOrderV4Request,
@@ -2530,6 +2611,7 @@ import {
   SubmittedSpotBatchOrderResponseV2,
   SubTransferRow,
   SymbolMarginAccountDetailsV1,
+  UapiKeyAccountInfoResponse,
   WithdrawAddressListItem,
 } from './types/response/spot.types.js';
 ⋮----
@@ -2661,9 +2743,23 @@ getSpotOrderBookDepthV1(
    *
    **/
 ⋮----
-getAccountBalancesV1(params?: {
-    currency?: string;
-}): Promise<APIResponse<
+getAccountBalancesV1(
+    params?: AccountBalancesV1Request,
+): Promise<APIResponse<
+⋮----
+/**
+   * Feature: Query account KYC and API key metadata (exchange update 2026-06-25).
+   * GET `uapi-key/v1/account/info`
+   */
+getAccountInfoV1(): Promise<UapiKeyAccountInfoResponse>
+⋮----
+/**
+   * Feature: Funding account transfer between funding and spot accounts (exchange update 2026-06-29).
+   * POST `account/v1/transfer`
+   */
+submitAccountTransferV1(
+    params: SubmitAccountTransferV1Request,
+): Promise<APIResponse<Record<string, never>>>
 ⋮----
 getAccountCurrenciesV1(params?: {
     currencies?: string;
@@ -3513,6 +3609,20 @@ amount: string; // Transfer amount, allowed range[0.01,10000000000]
 ⋮----
 recvWindow?: number; // Trade time limit, allowed range (0,60000], default: 5000 milliseconds
 ⋮----
+/** POST `contract/private/account/v1/transfer` — funding account ↔ futures account transfer. */
+export interface SubmitFuturesFundingAccountTransferRequest {
+  currency?: string;
+  amount?: string;
+  type?: 'fund_to_contract' | 'contract_to_fund';
+}
+⋮----
+/** POST `contract/private/close-all-position` — market-close all or filtered futures positions. */
+export interface CloseAllFuturesPositionsRequest {
+  symbol?: string;
+  contractType: 1 | 2;
+  position_side?: 'long' | 'short';
+}
+⋮----
 export interface SetFuturesLeverageRequest {
   symbol: string; // Symbol of the contract(like BTCUSDT)
   leverage?: string; // Order leverage
@@ -3664,6 +3774,11 @@ export interface FuturesAffiliateDepositWithdrawalListRequest {
   end_time: number;
 }
 ⋮----
+/** GET `contract/private/affiliate/invite-check` — check if a user CID was invited by the affiliate. */
+export interface FuturesAffiliateInviteCheckRequest {
+  cid: number;
+}
+⋮----
 /** GET `contract/public/funding-rate-v2` — optional symbol; omit to query all pairs. */
 export interface FuturesFundingRateV2Request {
   symbol?: string;
@@ -3695,147 +3810,6 @@ export interface FuturesAffiliateRebateApiRequest {
 export interface SubmitFuturesSimulatedClaimRequest {
   currency?: string;
   amount?: string;
-}
-
-================
-File: src/types/websockets/client.ts
-================
-import type { ClientRequestArgs } from 'http';
-import WebSocket from 'isomorphic-ws';
-⋮----
-/**
- * WS topics are always a string for bitmart. Some exchanges use complex objects
- */
-export type WsTopic = string;
-⋮----
-/**
- * Event args for subscribing/unsubscribing
- */
-⋮----
-// export type WsTopicSubscribePrivateArgsV2 =
-//   | WsTopicSubscribePrivateInstIdArgsV2
-//   | WsTopicSubscribePrivateCoinArgsV2;
-⋮----
-// export type WsTopicSubscribeEventArgsV2 =
-//   | WsTopicSubscribePublicArgsV2
-//   | WsTopicSubscribePrivateArgsV2;
-⋮----
-/** General configuration for the WebsocketClient */
-export interface WSClientConfigurableOptions {
-  /** Your API key */
-  apiKey?: string;
-
-  /** Your API secret */
-  apiSecret?: string;
-
-  /** Your API memo (can be anything) that you included when creating this API key */
-  apiMemo?: string;
-
-  /** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
-  recvWindow?: number;
-
-  /** How often to check if the connection is alive */
-  pingInterval?: number;
-
-  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-  pongTimeout?: number;
-
-  /** Delay in milliseconds before respawning the connection */
-  reconnectTimeout?: number;
-
-  requestOptions?: {};
-
-  wsOptions?: {
-    protocols?: string[];
-    agent?: any;
-  } & Partial<WebSocket.ClientOptions | ClientRequestArgs>;
-
-  wsUrl?: string;
-
-  /**
-   * Default: false. If true, use the simulated trading demo environment.
-   * For V2 Futures WebSocket: wss://openapi-wsdemo-v2.bitmart.com
-   * Note: The API keys for Simulated-Environment and Prod-Environment are the same.
-   */
-  demoTrading?: boolean;
-
-  /**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
-}
-⋮----
-/** Your API key */
-⋮----
-/** Your API secret */
-⋮----
-/** Your API memo (can be anything) that you included when creating this API key */
-⋮----
-/** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
-⋮----
-/** How often to check if the connection is alive */
-⋮----
-/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-⋮----
-/** Delay in milliseconds before respawning the connection */
-⋮----
-/**
-   * Default: false. If true, use the simulated trading demo environment.
-   * For V2 Futures WebSocket: wss://openapi-wsdemo-v2.bitmart.com
-   * Note: The API keys for Simulated-Environment and Prod-Environment are the same.
-   */
-⋮----
-/**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-⋮----
-/**
- * WS configuration that's always defined, regardless of user configuration
- * (usually comes from defaults if there's no user-provided values)
- */
-export interface WebsocketClientOptions extends WSClientConfigurableOptions {
-  pingInterval: number;
-  pongTimeout: number;
-  reconnectTimeout: number;
-  recvWindow: number;
-
-  /**
-   * If true, require a "receipt" that the connection is ready for use (e.g. a specific event type)
-   */
-  requireConnectionReadyConfirmation: boolean;
-  authPrivateConnectionsOnConnect: boolean;
-  authPrivateRequests: boolean;
-  reauthWSAPIOnReconnect: boolean;
-
-  /**
-   * Whether to use native WebSocket ping/pong frames for heartbeats
-   */
-  useNativeHeartbeats: boolean;
-}
-⋮----
-/**
-   * If true, require a "receipt" that the connection is ready for use (e.g. a specific event type)
-   */
-⋮----
-/**
-   * Whether to use native WebSocket ping/pong frames for heartbeats
-   */
-⋮----
-export type WsMarket = 'spot' | 'futures';
-⋮----
-/**
- * A midflight WS request event (e.g. subscribe to these topics).
- *
- * - requestKey: unique identifier for this request, if available. Can be anything as a string.
- * - requestEvent: the raw request, as an object, that will be sent on the ws connection. This may contain multiple topics/requests in one object, if the exchange supports it.
- */
-export interface MidflightWsRequestEvent<TEvent = object> {
-  requestKey: string;
-  requestEvent: TEvent;
 }
 
 ================
@@ -4270,6 +4244,673 @@ export interface FuturesSimulatedClaimResponse {
   currency: string;
   amount: string;
 }
+⋮----
+/** GET `contract/private/affiliate/invite-check` */
+export interface FuturesAffiliateInviteCheckResponse {
+  isInviteUser: boolean;
+}
+
+================
+File: src/types/websockets/client.ts
+================
+import type { ClientRequestArgs } from 'http';
+import WebSocket from 'isomorphic-ws';
+⋮----
+/**
+ * WS topics are always a string for bitmart. Some exchanges use complex objects
+ */
+export type WsTopic = string;
+⋮----
+/**
+ * Event args for subscribing/unsubscribing
+ */
+⋮----
+// export type WsTopicSubscribePrivateArgsV2 =
+//   | WsTopicSubscribePrivateInstIdArgsV2
+//   | WsTopicSubscribePrivateCoinArgsV2;
+⋮----
+// export type WsTopicSubscribeEventArgsV2 =
+//   | WsTopicSubscribePublicArgsV2
+//   | WsTopicSubscribePrivateArgsV2;
+⋮----
+/** General configuration for the WebsocketClient */
+export interface WSClientConfigurableOptions {
+  /** Your API key */
+  apiKey?: string;
+
+  /** Your API secret */
+  apiSecret?: string;
+
+  /** Your API memo (can be anything) that you included when creating this API key */
+  apiMemo?: string;
+
+  /** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
+  recvWindow?: number;
+
+  /** How often to check if the connection is alive */
+  pingInterval?: number;
+
+  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+  pongTimeout?: number;
+
+  /** Delay in milliseconds before respawning the connection */
+  reconnectTimeout?: number;
+
+  requestOptions?: {};
+
+  wsOptions?: {
+    protocols?: string[];
+    agent?: any;
+  } & Partial<WebSocket.ClientOptions | ClientRequestArgs>;
+
+  wsUrl?: string;
+
+  /**
+   * Default: false. If true, use the simulated trading demo environment.
+   * For V2 Futures WebSocket: wss://openapi-wsdemo-v2.bitmart.com
+   * Note: The API keys for Simulated-Environment and Prod-Environment are the same.
+   */
+  demoTrading?: boolean;
+
+  /**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
+}
+⋮----
+/** Your API key */
+⋮----
+/** Your API secret */
+⋮----
+/** Your API memo (can be anything) that you included when creating this API key */
+⋮----
+/** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
+⋮----
+/** How often to check if the connection is alive */
+⋮----
+/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+⋮----
+/** Delay in milliseconds before respawning the connection */
+⋮----
+/**
+   * Default: false. If true, use the simulated trading demo environment.
+   * For V2 Futures WebSocket: wss://openapi-wsdemo-v2.bitmart.com
+   * Note: The API keys for Simulated-Environment and Prod-Environment are the same.
+   */
+⋮----
+/**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+⋮----
+/**
+ * WS configuration that's always defined, regardless of user configuration
+ * (usually comes from defaults if there's no user-provided values)
+ */
+export interface WebsocketClientOptions extends WSClientConfigurableOptions {
+  pingInterval: number;
+  pongTimeout: number;
+  reconnectTimeout: number;
+  recvWindow: number;
+
+  /**
+   * If true, require a "receipt" that the connection is ready for use (e.g. a specific event type)
+   */
+  requireConnectionReadyConfirmation: boolean;
+  authPrivateConnectionsOnConnect: boolean;
+  authPrivateRequests: boolean;
+  reauthWSAPIOnReconnect: boolean;
+
+  /**
+   * Whether to use native WebSocket ping/pong frames for heartbeats
+   */
+  useNativeHeartbeats: boolean;
+}
+⋮----
+/**
+   * If true, require a "receipt" that the connection is ready for use (e.g. a specific event type)
+   */
+⋮----
+/**
+   * Whether to use native WebSocket ping/pong frames for heartbeats
+   */
+⋮----
+export type WsMarket = 'spot' | 'futures';
+⋮----
+/**
+ * A midflight WS request event (e.g. subscribe to these topics).
+ *
+ * - requestKey: unique identifier for this request, if available. Can be anything as a string.
+ * - requestEvent: the raw request, as an object, that will be sent on the ws connection. This may contain multiple topics/requests in one object, if the exchange supports it.
+ */
+export interface MidflightWsRequestEvent<TEvent = object> {
+  requestKey: string;
+  requestEvent: TEvent;
+}
+
+================
+File: src/FuturesClientV2.ts
+================
+import { AxiosRequestConfig } from 'axios';
+⋮----
+import {
+  BaseRestClient,
+  REST_CLIENT_TYPE_ENUM,
+  RestClientType,
+} from './lib/BaseRestClient.js';
+import { RestClientOptions } from './lib/requestUtils.js';
+import {
+  CancelFuturesOrderRequest,
+  CancelFuturesPlanOrderRequest,
+  CancelFuturesTrailOrderRequest,
+  CloseAllFuturesPositionsRequest,
+  FuturesAccountHistoricOrderRequest,
+  FuturesAccountHistoricTransactionRequest,
+  FuturesAccountOpenOrdersRequest,
+  FuturesAccountPlanOrdersRequest,
+  FuturesAccountTradesRequest,
+  FuturesAccountTransfersRequest,
+  FuturesAffiliateCustomerInfoRequest,
+  FuturesAffiliateDepositWithdrawalListRequest,
+  FuturesAffiliateInviteCheckRequest,
+  FuturesAffiliateRebateApiRequest,
+  FuturesAffiliateRebateInviteUserRequest,
+  FuturesAffiliateRebatesRequest,
+  FuturesAffiliateRebateUserRequest,
+  FuturesAffiliateTradesRequest,
+  FuturesAutoRepaymentRequest,
+  FuturesCrossCollateralInterestLogRequest,
+  FuturesFundingRateV2Request,
+  FuturesKlinesRequest,
+  FuturesSubTransfersRequest,
+  FuturesSubWalletRequest,
+  GetFuturesOrderRequest,
+  SetFuturesLeverageRequest,
+  SubmitFuturesFundingAccountTransferRequest,
+  SubmitFuturesOrderRequest,
+  SubmitFuturesPlanOrderRequest,
+  SubmitFuturesSimulatedClaimRequest,
+  SubmitFuturesSubToMainSubFromSubRequest,
+  SubmitFuturesTPSLOrderRequest,
+  SubmitFuturesTrailOrderRequest,
+  SubmitFuturesTransferRequest,
+  TransferFuturesAssetsRequest,
+  UpdateFuturesLimitOrderRequest,
+  UpdateFuturesPlanOrderRequest,
+  UpdateFuturesPresetPlanOrderRequest,
+  UpdateFuturesTPSLOrderRequest,
+} from './types/request/futures.types.js';
+import {
+  FuturesAccountAsset,
+  FuturesAccountHistoricOrder,
+  FuturesAccountHistoricTransaction,
+  FuturesAccountOpenOrder,
+  FuturesAccountOrder,
+  FuturesAccountPlanOrders,
+  FuturesAccountPosition,
+  FuturesAccountPositionV2,
+  FuturesAccountSetLeverageResult,
+  FuturesAccountSubTransfer,
+  FuturesAccountTrade,
+  FuturesAccountTransfer,
+  FuturesAffiliateCustomerInfoResponse,
+  FuturesAffiliateDepositWithdrawalListResult,
+  FuturesAffiliateInviteCheckResponse,
+  FuturesAffiliateRebateApiResponse,
+  FuturesAffiliateRebateInviteUserResponse,
+  FuturesAffiliateRebateUserResponse,
+  FuturesAutoRepaymentApiResponse,
+  FuturesContractDepth,
+  FuturesContractDetails,
+  FuturesCrossCollateralInterestLogApiResponse,
+  FuturesFundingRate,
+  FuturesFundingRateHistory,
+  FuturesFundingRateV2Response,
+  FuturesKline,
+  FuturesLeverageBracketRule,
+  FuturesMarketTrade,
+  FuturesOpenInterest,
+  FuturesOrderSubmitResult,
+  FuturesSimulatedClaimResponse,
+  FuturesTransferSubmitResult,
+  PositionRisk,
+} from './types/response/futures.types.js';
+import {
+  AccountCurrencyBalanceV1,
+  APIResponse,
+} from './types/response/shared.types.js';
+import { ServiceStatus } from './types/response/spot.types.js';
+⋮----
+/**
+ * REST API client for Bitmart's V2 Futures APIs via the "api-cloud-v2.bitmart.com" domain
+ */
+export class FuturesClientV2 extends BaseRestClient
+⋮----
+constructor(
+    restClientOptions: RestClientOptions = {},
+    requestOptions: AxiosRequestConfig = {},
+)
+⋮----
+getClientType(): RestClientType
+⋮----
+/**
+   *
+   * System Status Endpoints
+   *
+   **/
+⋮----
+getSystemTime(): Promise<APIResponse<
+⋮----
+getSystemStatus(): Promise<APIResponse<
+⋮----
+/**
+   *
+   *****************
+   * USD-M Futures V2 *
+   *****************
+   *
+   */
+⋮----
+/**
+   *
+   * Futures Market Data
+   *
+   */
+⋮----
+/**
+   * Get a list of all symbols, including most recent price, rules (min/max precision/volume/etc) and other metrics (funding rate, open interest, contract expiry, etc).
+   */
+getFuturesContractDetails(params?: {
+    symbol?: string;
+}): Promise<APIResponse<
+⋮----
+getFuturesContractDepth(params: {
+    symbol: string;
+}): Promise<APIResponse<FuturesContractDepth>>
+⋮----
+getFuturesMarketTrade(params: {
+    symbol: string;
+    limit?: number; // Default 50; max 100
+}): Promise<APIResponse<FuturesMarketTrade[]>>
+⋮----
+limit?: number; // Default 50; max 100
+⋮----
+getFuturesOpenInterest(params: {
+    symbol: string;
+}): Promise<APIResponse<FuturesOpenInterest>>
+⋮----
+getFuturesFundingRate(params: {
+    symbol: string;
+}): Promise<APIResponse<FuturesFundingRate>>
+⋮----
+/**
+   * Current funding rate for one or all contract pairs.
+   * GET `contract/public/funding-rate-v2`
+   */
+getFuturesFundingRateV2(
+    params?: FuturesFundingRateV2Request,
+): Promise<APIResponse<FuturesFundingRateV2Response>>
+⋮----
+getFuturesKlines(
+    params: FuturesKlinesRequest,
+): Promise<APIResponse<FuturesKline[]>>
+⋮----
+getFuturesMarkPriceKlines(
+    params: FuturesKlinesRequest,
+): Promise<APIResponse<FuturesKline[]>>
+⋮----
+getFuturesFundingRateHistory(params: {
+    symbol: string;
+    limit?: string;
+  }): Promise<
+    APIResponse<{
+      list: FuturesFundingRateHistory[];
+    }>
+  > {
+    return this.get('contract/public/funding-rate-history', params);
+⋮----
+/**
+   * Get current leverage risk limit for a specified contract
+   * @param params Optional parameters including symbol
+   * @returns Promise with leverage bracket information
+   */
+getFuturesLeverageBracket(params?: { symbol?: string }): Promise<
+    APIResponse<{
+      rules: FuturesLeverageBracketRule[];
+    }>
+  > {
+    return this.get('contract/public/leverage-bracket', params);
+⋮----
+/**
+   *
+   * Futures Account Data
+   *
+   */
+⋮----
+getFuturesAccountAssets(): Promise<APIResponse<FuturesAccountAsset[]>>
+⋮----
+/**
+   *
+   * Futures Trading
+   *
+   */
+⋮----
+getFuturesTradeFeeRate(params: { symbol: string }): Promise<
+    APIResponse<{
+      symbol: string;
+      taker_fee_rate: string;
+      maker_fee_rate: string;
+    }>
+  > {
+    return this.getPrivate('contract/private/trade-fee-rate', params);
+⋮----
+getFuturesAccountOrder(
+    params: GetFuturesOrderRequest,
+): Promise<APIResponse<FuturesAccountOrder>>
+⋮----
+getFuturesAccountOrderHistory(
+    params: FuturesAccountHistoricOrderRequest,
+): Promise<APIResponse<FuturesAccountHistoricOrder>>
+⋮----
+getFuturesAccountOpenOrders(
+    params?: FuturesAccountOpenOrdersRequest,
+): Promise<APIResponse<FuturesAccountOpenOrder[]>>
+⋮----
+getFuturesAccountPlanOrders(
+    params?: FuturesAccountPlanOrdersRequest,
+): Promise<APIResponse<FuturesAccountPlanOrders[]>>
+⋮----
+getFuturesAccountPositions(params?: {
+    symbol?: string;
+    account?: string;
+}): Promise<APIResponse<FuturesAccountPosition[]>>
+⋮----
+getFuturesAccountPositionsV2(params?: {
+    symbol?: string;
+    account?: string;
+}): Promise<APIResponse<FuturesAccountPositionV2[]>>
+⋮----
+/**
+   * Get current position risk details
+   */
+getPositionRiskDetails(params?: {
+    symbol?: string;
+    account?: string;
+}): Promise<APIResponse<PositionRisk[]>>
+⋮----
+getFuturesAccountTrades(
+    params: FuturesAccountTradesRequest,
+): Promise<APIResponse<FuturesAccountTrade[]>>
+⋮----
+getFuturesAccountTransactionHistory(
+    params: FuturesAccountHistoricTransactionRequest,
+): Promise<APIResponse<FuturesAccountHistoricTransaction[]>>
+⋮----
+/**
+   * Query auto repayment records (KEYED). Defaults to last 7 days if times omitted; max 20 records per request.
+   */
+getFuturesAutoRepayment(
+    params?: FuturesAutoRepaymentRequest,
+): Promise<FuturesAutoRepaymentApiResponse>
+⋮----
+/**
+   * Query cross margin interest accrual logs (KEYED). Defaults to last 7 days; max interval 90 days; max 20 records per request.
+   */
+getFuturesCrossCollateralInterestLog(
+    params?: FuturesCrossCollateralInterestLogRequest,
+): Promise<FuturesCrossCollateralInterestLogApiResponse>
+⋮----
+getFuturesTransfers(params: FuturesAccountTransfersRequest): Promise<
+    APIResponse<{
+      records: FuturesAccountTransfer[];
+    }>
+  > {
+    return this.getPrivate('account/v1/transfer-contract-list', params);
+⋮----
+submitFuturesOrder(
+    params: SubmitFuturesOrderRequest,
+): Promise<APIResponse<FuturesOrderSubmitResult>>
+⋮----
+updateFuturesLimitOrder(params: UpdateFuturesLimitOrderRequest): Promise<
+    APIResponse<{
+      order_id: number;
+      client_order_id?: string;
+    }>
+  > {
+    return this.postPrivate('contract/private/modify-limit-order', params);
+⋮----
+cancelFuturesOrder(
+    params: CancelFuturesOrderRequest,
+): Promise<APIResponse<any>>
+⋮----
+cancelAllFuturesOrders(params: {
+    symbol: string;
+}): Promise<APIResponse<any>>
+⋮----
+cancelAllFuturesOrdersAfter(params: {
+    timeout: number;
+    symbol: string;
+}): Promise<APIResponse<any>>
+⋮----
+/**
+   * Feature: Market-close all or filtered futures positions (exchange update 2026-06-16).
+   * POST `contract/private/close-all-position`
+   */
+closeAllFuturesPositions(
+    params: CloseAllFuturesPositionsRequest,
+): Promise<APIResponse<Record<string, never>>>
+⋮----
+submitFuturesPlanOrder(params: SubmitFuturesPlanOrderRequest): Promise<
+    APIResponse<{
+      order_id: number;
+    }>
+  > {
+    return this.postPrivate('contract/private/submit-plan-order', params);
+⋮----
+cancelFuturesPlanOrder(
+    params: CancelFuturesPlanOrderRequest,
+): Promise<APIResponse<any>>
+⋮----
+submitFuturesTransfer(
+    params: SubmitFuturesTransferRequest,
+): Promise<APIResponse<FuturesTransferSubmitResult>>
+⋮----
+/**
+   * Feature: Funding account transfer between funding and futures accounts (exchange update 2026-06-29).
+   * POST `contract/private/account/v1/transfer`
+   */
+submitFuturesFundingAccountTransfer(
+    params: SubmitFuturesFundingAccountTransferRequest,
+): Promise<APIResponse<Record<string, never>>>
+⋮----
+setFuturesLeverage(
+    params: SetFuturesLeverageRequest,
+): Promise<APIResponse<FuturesAccountSetLeverageResult>>
+⋮----
+submitFuturesTPSLOrder(params: SubmitFuturesTPSLOrderRequest): Promise<
+    APIResponse<{
+      order_id: string;
+      client_order_id?: string;
+    }>
+  > {
+    return this.postPrivate('contract/private/submit-tp-sl-order', params);
+⋮----
+updateFuturesPlanOrder(params: UpdateFuturesPlanOrderRequest): Promise<
+    APIResponse<{
+      order_id: string;
+    }>
+  > {
+    return this.postPrivate('contract/private/modify-plan-order', params);
+⋮----
+updateFuturesPresetPlanOrder(
+    params: UpdateFuturesPresetPlanOrderRequest,
+  ): Promise<
+    APIResponse<{
+      order_id: string;
+    }>
+  > {
+    return this.postPrivate(
+      'contract/private/modify-preset-plan-order',
+      params,
+    );
+⋮----
+updateFuturesTPSLOrder(params: UpdateFuturesTPSLOrderRequest): Promise<
+    APIResponse<{
+      order_id: string;
+    }>
+  > {
+    return this.postPrivate('contract/private/modify-tp-sl-order', params);
+⋮----
+submitFuturesTrailOrder(params: SubmitFuturesTrailOrderRequest): Promise<
+    APIResponse<{
+      order_id: number;
+    }>
+  > {
+    return this.postPrivate('contract/private/submit-trail-order', params);
+⋮----
+cancelFuturesTrailOrder(
+    params: CancelFuturesTrailOrderRequest,
+): Promise<APIResponse<any>>
+⋮----
+/**
+   * Set position mode (hedge_mode or one_way_mode)
+   */
+setPositionMode(params: {
+    position_mode: 'hedge_mode' | 'one_way_mode';
+}): Promise<APIResponse<
+⋮----
+/**
+   * Get current position mode
+   */
+getPositionMode(): Promise<
+    APIResponse<{ position_mode: 'hedge_mode' | 'one_way_mode' }>
+  > {
+    return this.getPrivate('contract/private/get-position-mode');
+⋮----
+/**
+   *
+   * Futures Sub-Account Endpoints
+   *
+   */
+⋮----
+submitFuturesSubToMainTransferFromMain(
+    params: TransferFuturesAssetsRequest,
+): Promise<APIResponse<any>>
+⋮----
+submitFuturesMainToSubTransferFromMain(
+    params: TransferFuturesAssetsRequest,
+): Promise<APIResponse<any>>
+⋮----
+submitFuturesSubToMainSubFromSub(
+    params: SubmitFuturesSubToMainSubFromSubRequest,
+): Promise<APIResponse<any>>
+⋮----
+getFuturesSubWallet(params?: FuturesSubWalletRequest): Promise<
+    APIResponse<{
+      wallet: AccountCurrencyBalanceV1[];
+    }>
+  > {
+    return this.getPrivate(
+      'account/contract/sub-account/main/v1/wallet',
+      params,
+    );
+⋮----
+getFuturesSubTransfers(
+    params: FuturesSubTransfersRequest,
+): Promise<APIResponse<FuturesAccountSubTransfer[]>>
+⋮----
+getFuturesSubTransferHistory(params: {
+    limit: number; // Range [1,100]
+}): Promise<APIResponse<FuturesAccountSubTransfer[]>>
+⋮----
+limit: number; // Range [1,100]
+⋮----
+/**
+   *
+   * Futures Affiliate Endpoints
+   *
+   */
+⋮----
+getFuturesAffiliateRebates(
+    params: FuturesAffiliateRebatesRequest,
+): Promise<APIResponse<any>>
+⋮----
+getFuturesAffiliateTrades(
+    params: FuturesAffiliateTradesRequest,
+): Promise<APIResponse<any>>
+⋮----
+/**
+   * Get single user rebate data (KEYED)
+   * GET `contract/private/affiliate/rebate-user`
+   */
+getFuturesAffiliateRebateUser(
+    params: FuturesAffiliateRebateUserRequest,
+): Promise<APIResponse<FuturesAffiliateRebateUserResponse>>
+⋮----
+/**
+   * Feature: Check if a user CID was invited by the affiliate (exchange update 2026-02-03).
+   * GET `contract/private/affiliate/invite-check`
+   */
+getFuturesAffiliateInviteCheck(
+    params: FuturesAffiliateInviteCheckRequest,
+): Promise<APIResponse<FuturesAffiliateInviteCheckResponse>>
+⋮----
+/**
+   * Invited user contract account total assets and equity (USDT).
+   * GET `contract/private/affiliate/aff-customer-info`
+   */
+getFuturesAffiliateCustomerInfo(
+    params: FuturesAffiliateCustomerInfoRequest,
+): Promise<APIResponse<FuturesAffiliateCustomerInfoResponse>>
+⋮----
+/**
+   * Get invited customer list (KEYED)
+   * GET `contract/private/affiliate/rebate-inviteUser`
+   * Feature: list entries include `accountAssetTotal` (exchange update 2026-04-07).
+   */
+getFuturesAffiliateRebateInviteUser(
+    params: FuturesAffiliateRebateInviteUserRequest,
+): Promise<APIResponse<FuturesAffiliateRebateInviteUserResponse>>
+⋮----
+/**
+   * Get API Rebate Data (KEYED)
+   * Used for API affiliates to query contract API rebate data within a certain time range
+   * Feature: Query up to 60 days of data
+   */
+getFuturesAffiliateRebateApi(
+    params: FuturesAffiliateRebateApiRequest,
+): Promise<APIResponse<FuturesAffiliateRebateApiResponse>>
+⋮----
+/**
+   * Deposit and withdrawal information of invited users (KEYED)
+   * Feature: Query up to 60 days; max 50 records per page (exchange update 2026-04-07).
+   */
+getFuturesAffiliateDepositWithdrawalList(
+    params: FuturesAffiliateDepositWithdrawalListRequest,
+): Promise<FuturesAffiliateDepositWithdrawalListResult>
+⋮----
+/**
+   * Simulated Claim (SIGNED)
+   * Add available funds to the futures account (Only available in the Simulated-Environment)
+   *
+   * Note: This endpoint is only available in the Simulated Trading environment.
+   * To use this endpoint, create a client instance with demoTrading: true
+   * Example:
+   *   const simulatedClient = new FuturesClientV2({
+   *     apiKey: 'your-api-key',
+   *     apiSecret: 'your-api-secret',
+   *     apiMemo: 'your-api-memo',
+   *     demoTrading: true
+   *   });
+   *
+   * Alternatively, you can manually set baseUrl: 'https://demo-api-cloud-v2.bitmart.com'
+   */
+submitFuturesSimulatedClaim(
+    params?: SubmitFuturesSimulatedClaimRequest,
+): Promise<APIResponse<FuturesSimulatedClaimResponse>>
 
 ================
 File: src/lib/BaseWSClient.ts
@@ -5102,499 +5743,6 @@ private arrangeTopicsIntoWsKeyGroups(
 // Backwards comaptibility with how old subscribe method worked:
 
 ================
-File: src/FuturesClientV2.ts
-================
-import { AxiosRequestConfig } from 'axios';
-⋮----
-import {
-  BaseRestClient,
-  REST_CLIENT_TYPE_ENUM,
-  RestClientType,
-} from './lib/BaseRestClient.js';
-import { RestClientOptions } from './lib/requestUtils.js';
-import {
-  CancelFuturesOrderRequest,
-  CancelFuturesPlanOrderRequest,
-  CancelFuturesTrailOrderRequest,
-  FuturesAccountHistoricOrderRequest,
-  FuturesAccountHistoricTransactionRequest,
-  FuturesAccountOpenOrdersRequest,
-  FuturesAccountPlanOrdersRequest,
-  FuturesAccountTradesRequest,
-  FuturesAccountTransfersRequest,
-  FuturesAffiliateCustomerInfoRequest,
-  FuturesAffiliateDepositWithdrawalListRequest,
-  FuturesAffiliateRebateApiRequest,
-  FuturesAffiliateRebateInviteUserRequest,
-  FuturesAffiliateRebatesRequest,
-  FuturesAffiliateRebateUserRequest,
-  FuturesAffiliateTradesRequest,
-  FuturesAutoRepaymentRequest,
-  FuturesCrossCollateralInterestLogRequest,
-  FuturesFundingRateV2Request,
-  FuturesKlinesRequest,
-  FuturesSubTransfersRequest,
-  FuturesSubWalletRequest,
-  GetFuturesOrderRequest,
-  SetFuturesLeverageRequest,
-  SubmitFuturesOrderRequest,
-  SubmitFuturesPlanOrderRequest,
-  SubmitFuturesSimulatedClaimRequest,
-  SubmitFuturesSubToMainSubFromSubRequest,
-  SubmitFuturesTPSLOrderRequest,
-  SubmitFuturesTrailOrderRequest,
-  SubmitFuturesTransferRequest,
-  TransferFuturesAssetsRequest,
-  UpdateFuturesLimitOrderRequest,
-  UpdateFuturesPlanOrderRequest,
-  UpdateFuturesPresetPlanOrderRequest,
-  UpdateFuturesTPSLOrderRequest,
-} from './types/request/futures.types.js';
-import {
-  FuturesAccountAsset,
-  FuturesAccountHistoricOrder,
-  FuturesAccountHistoricTransaction,
-  FuturesAccountOpenOrder,
-  FuturesAccountOrder,
-  FuturesAccountPlanOrders,
-  FuturesAccountPosition,
-  FuturesAccountPositionV2,
-  FuturesAccountSetLeverageResult,
-  FuturesAccountSubTransfer,
-  FuturesAccountTrade,
-  FuturesAccountTransfer,
-  FuturesAffiliateCustomerInfoResponse,
-  FuturesAffiliateDepositWithdrawalListResult,
-  FuturesAffiliateRebateApiResponse,
-  FuturesAffiliateRebateInviteUserResponse,
-  FuturesAffiliateRebateUserResponse,
-  FuturesAutoRepaymentApiResponse,
-  FuturesContractDepth,
-  FuturesContractDetails,
-  FuturesCrossCollateralInterestLogApiResponse,
-  FuturesFundingRate,
-  FuturesFundingRateHistory,
-  FuturesFundingRateV2Response,
-  FuturesKline,
-  FuturesLeverageBracketRule,
-  FuturesMarketTrade,
-  FuturesOpenInterest,
-  FuturesOrderSubmitResult,
-  FuturesSimulatedClaimResponse,
-  FuturesTransferSubmitResult,
-  PositionRisk,
-} from './types/response/futures.types.js';
-import {
-  AccountCurrencyBalanceV1,
-  APIResponse,
-} from './types/response/shared.types.js';
-import { ServiceStatus } from './types/response/spot.types.js';
-⋮----
-/**
- * REST API client for Bitmart's V2 Futures APIs via the "api-cloud-v2.bitmart.com" domain
- */
-export class FuturesClientV2 extends BaseRestClient
-⋮----
-constructor(
-    restClientOptions: RestClientOptions = {},
-    requestOptions: AxiosRequestConfig = {},
-)
-⋮----
-getClientType(): RestClientType
-⋮----
-/**
-   *
-   * System Status Endpoints
-   *
-   **/
-⋮----
-getSystemTime(): Promise<APIResponse<
-⋮----
-getSystemStatus(): Promise<APIResponse<
-⋮----
-/**
-   *
-   *****************
-   * USD-M Futures V2 *
-   *****************
-   *
-   */
-⋮----
-/**
-   *
-   * Futures Market Data
-   *
-   */
-⋮----
-/**
-   * Get a list of all symbols, including most recent price, rules (min/max precision/volume/etc) and other metrics (funding rate, open interest, contract expiry, etc).
-   */
-getFuturesContractDetails(params?: {
-    symbol?: string;
-}): Promise<APIResponse<
-⋮----
-getFuturesContractDepth(params: {
-    symbol: string;
-}): Promise<APIResponse<FuturesContractDepth>>
-⋮----
-getFuturesMarketTrade(params: {
-    symbol: string;
-    limit?: number; // Default 50; max 100
-}): Promise<APIResponse<FuturesMarketTrade[]>>
-⋮----
-limit?: number; // Default 50; max 100
-⋮----
-getFuturesOpenInterest(params: {
-    symbol: string;
-}): Promise<APIResponse<FuturesOpenInterest>>
-⋮----
-getFuturesFundingRate(params: {
-    symbol: string;
-}): Promise<APIResponse<FuturesFundingRate>>
-⋮----
-/**
-   * Current funding rate for one or all contract pairs.
-   * GET `contract/public/funding-rate-v2`
-   */
-getFuturesFundingRateV2(
-    params?: FuturesFundingRateV2Request,
-): Promise<APIResponse<FuturesFundingRateV2Response>>
-⋮----
-getFuturesKlines(
-    params: FuturesKlinesRequest,
-): Promise<APIResponse<FuturesKline[]>>
-⋮----
-getFuturesMarkPriceKlines(
-    params: FuturesKlinesRequest,
-): Promise<APIResponse<FuturesKline[]>>
-⋮----
-getFuturesFundingRateHistory(params: {
-    symbol: string;
-    limit?: string;
-  }): Promise<
-    APIResponse<{
-      list: FuturesFundingRateHistory[];
-    }>
-  > {
-    return this.get('contract/public/funding-rate-history', params);
-⋮----
-/**
-   * Get current leverage risk limit for a specified contract
-   * @param params Optional parameters including symbol
-   * @returns Promise with leverage bracket information
-   */
-getFuturesLeverageBracket(params?: { symbol?: string }): Promise<
-    APIResponse<{
-      rules: FuturesLeverageBracketRule[];
-    }>
-  > {
-    return this.get('contract/public/leverage-bracket', params);
-⋮----
-/**
-   *
-   * Futures Account Data
-   *
-   */
-⋮----
-getFuturesAccountAssets(): Promise<APIResponse<FuturesAccountAsset[]>>
-⋮----
-/**
-   *
-   * Futures Trading
-   *
-   */
-⋮----
-getFuturesTradeFeeRate(params: { symbol: string }): Promise<
-    APIResponse<{
-      symbol: string;
-      taker_fee_rate: string;
-      maker_fee_rate: string;
-    }>
-  > {
-    return this.getPrivate('contract/private/trade-fee-rate', params);
-⋮----
-getFuturesAccountOrder(
-    params: GetFuturesOrderRequest,
-): Promise<APIResponse<FuturesAccountOrder>>
-⋮----
-getFuturesAccountOrderHistory(
-    params: FuturesAccountHistoricOrderRequest,
-): Promise<APIResponse<FuturesAccountHistoricOrder>>
-⋮----
-getFuturesAccountOpenOrders(
-    params?: FuturesAccountOpenOrdersRequest,
-): Promise<APIResponse<FuturesAccountOpenOrder[]>>
-⋮----
-getFuturesAccountPlanOrders(
-    params?: FuturesAccountPlanOrdersRequest,
-): Promise<APIResponse<FuturesAccountPlanOrders[]>>
-⋮----
-getFuturesAccountPositions(params?: {
-    symbol?: string;
-    account?: string;
-}): Promise<APIResponse<FuturesAccountPosition[]>>
-⋮----
-getFuturesAccountPositionsV2(params?: {
-    symbol?: string;
-    account?: string;
-}): Promise<APIResponse<FuturesAccountPositionV2[]>>
-⋮----
-/**
-   * Get current position risk details
-   */
-getPositionRiskDetails(params?: {
-    symbol?: string;
-    account?: string;
-}): Promise<APIResponse<PositionRisk[]>>
-⋮----
-getFuturesAccountTrades(
-    params: FuturesAccountTradesRequest,
-): Promise<APIResponse<FuturesAccountTrade[]>>
-⋮----
-getFuturesAccountTransactionHistory(
-    params: FuturesAccountHistoricTransactionRequest,
-): Promise<APIResponse<FuturesAccountHistoricTransaction[]>>
-⋮----
-/**
-   * Query auto repayment records (KEYED). Defaults to last 7 days if times omitted; max 20 records per request.
-   */
-getFuturesAutoRepayment(
-    params?: FuturesAutoRepaymentRequest,
-): Promise<FuturesAutoRepaymentApiResponse>
-⋮----
-/**
-   * Query cross margin interest accrual logs (KEYED). Defaults to last 7 days; max interval 90 days; max 20 records per request.
-   */
-getFuturesCrossCollateralInterestLog(
-    params?: FuturesCrossCollateralInterestLogRequest,
-): Promise<FuturesCrossCollateralInterestLogApiResponse>
-⋮----
-getFuturesTransfers(params: FuturesAccountTransfersRequest): Promise<
-    APIResponse<{
-      records: FuturesAccountTransfer[];
-    }>
-  > {
-    return this.getPrivate('account/v1/transfer-contract-list', params);
-⋮----
-submitFuturesOrder(
-    params: SubmitFuturesOrderRequest,
-): Promise<APIResponse<FuturesOrderSubmitResult>>
-⋮----
-updateFuturesLimitOrder(params: UpdateFuturesLimitOrderRequest): Promise<
-    APIResponse<{
-      order_id: number;
-      client_order_id?: string;
-    }>
-  > {
-    return this.postPrivate('contract/private/modify-limit-order', params);
-⋮----
-cancelFuturesOrder(
-    params: CancelFuturesOrderRequest,
-): Promise<APIResponse<any>>
-⋮----
-cancelAllFuturesOrders(params: {
-    symbol: string;
-}): Promise<APIResponse<any>>
-⋮----
-cancelAllFuturesOrdersAfter(params: {
-    timeout: number;
-    symbol: string;
-}): Promise<APIResponse<any>>
-⋮----
-submitFuturesPlanOrder(params: SubmitFuturesPlanOrderRequest): Promise<
-    APIResponse<{
-      order_id: number;
-    }>
-  > {
-    return this.postPrivate('contract/private/submit-plan-order', params);
-⋮----
-cancelFuturesPlanOrder(
-    params: CancelFuturesPlanOrderRequest,
-): Promise<APIResponse<any>>
-⋮----
-submitFuturesTransfer(
-    params: SubmitFuturesTransferRequest,
-): Promise<APIResponse<FuturesTransferSubmitResult>>
-⋮----
-setFuturesLeverage(
-    params: SetFuturesLeverageRequest,
-): Promise<APIResponse<FuturesAccountSetLeverageResult>>
-⋮----
-submitFuturesTPSLOrder(params: SubmitFuturesTPSLOrderRequest): Promise<
-    APIResponse<{
-      order_id: string;
-      client_order_id?: string;
-    }>
-  > {
-    return this.postPrivate('contract/private/submit-tp-sl-order', params);
-⋮----
-updateFuturesPlanOrder(params: UpdateFuturesPlanOrderRequest): Promise<
-    APIResponse<{
-      order_id: string;
-    }>
-  > {
-    return this.postPrivate('contract/private/modify-plan-order', params);
-⋮----
-updateFuturesPresetPlanOrder(
-    params: UpdateFuturesPresetPlanOrderRequest,
-  ): Promise<
-    APIResponse<{
-      order_id: string;
-    }>
-  > {
-    return this.postPrivate(
-      'contract/private/modify-preset-plan-order',
-      params,
-    );
-⋮----
-updateFuturesTPSLOrder(params: UpdateFuturesTPSLOrderRequest): Promise<
-    APIResponse<{
-      order_id: string;
-    }>
-  > {
-    return this.postPrivate('contract/private/modify-tp-sl-order', params);
-⋮----
-submitFuturesTrailOrder(params: SubmitFuturesTrailOrderRequest): Promise<
-    APIResponse<{
-      order_id: number;
-    }>
-  > {
-    return this.postPrivate('contract/private/submit-trail-order', params);
-⋮----
-cancelFuturesTrailOrder(
-    params: CancelFuturesTrailOrderRequest,
-): Promise<APIResponse<any>>
-⋮----
-/**
-   * Set position mode (hedge_mode or one_way_mode)
-   */
-setPositionMode(params: {
-    position_mode: 'hedge_mode' | 'one_way_mode';
-}): Promise<APIResponse<
-⋮----
-/**
-   * Get current position mode
-   */
-getPositionMode(): Promise<
-    APIResponse<{ position_mode: 'hedge_mode' | 'one_way_mode' }>
-  > {
-    return this.getPrivate('contract/private/get-position-mode');
-⋮----
-/**
-   *
-   * Futures Sub-Account Endpoints
-   *
-   */
-⋮----
-submitFuturesSubToMainTransferFromMain(
-    params: TransferFuturesAssetsRequest,
-): Promise<APIResponse<any>>
-⋮----
-submitFuturesMainToSubTransferFromMain(
-    params: TransferFuturesAssetsRequest,
-): Promise<APIResponse<any>>
-⋮----
-submitFuturesSubToMainSubFromSub(
-    params: SubmitFuturesSubToMainSubFromSubRequest,
-): Promise<APIResponse<any>>
-⋮----
-getFuturesSubWallet(params?: FuturesSubWalletRequest): Promise<
-    APIResponse<{
-      wallet: AccountCurrencyBalanceV1[];
-    }>
-  > {
-    return this.getPrivate(
-      'account/contract/sub-account/main/v1/wallet',
-      params,
-    );
-⋮----
-getFuturesSubTransfers(
-    params: FuturesSubTransfersRequest,
-): Promise<APIResponse<FuturesAccountSubTransfer[]>>
-⋮----
-getFuturesSubTransferHistory(params: {
-    limit: number; // Range [1,100]
-}): Promise<APIResponse<FuturesAccountSubTransfer[]>>
-⋮----
-limit: number; // Range [1,100]
-⋮----
-/**
-   *
-   * Futures Affiliate Endpoints
-   *
-   */
-⋮----
-getFuturesAffiliateRebates(
-    params: FuturesAffiliateRebatesRequest,
-): Promise<APIResponse<any>>
-⋮----
-getFuturesAffiliateTrades(
-    params: FuturesAffiliateTradesRequest,
-): Promise<APIResponse<any>>
-⋮----
-/**
-   * Get single user rebate data (KEYED)
-   * GET `contract/private/affiliate/rebate-user`
-   */
-getFuturesAffiliateRebateUser(
-    params: FuturesAffiliateRebateUserRequest,
-): Promise<APIResponse<FuturesAffiliateRebateUserResponse>>
-⋮----
-/**
-   * Invited user contract account total assets and equity (USDT).
-   * GET `contract/private/affiliate/aff-customer-info`
-   */
-getFuturesAffiliateCustomerInfo(
-    params: FuturesAffiliateCustomerInfoRequest,
-): Promise<APIResponse<FuturesAffiliateCustomerInfoResponse>>
-⋮----
-/**
-   * Get invited customer list (KEYED)
-   * GET `contract/private/affiliate/rebate-inviteUser`
-   * Feature: list entries include `accountAssetTotal` (exchange update 2026-04-07).
-   */
-getFuturesAffiliateRebateInviteUser(
-    params: FuturesAffiliateRebateInviteUserRequest,
-): Promise<APIResponse<FuturesAffiliateRebateInviteUserResponse>>
-⋮----
-/**
-   * Get API Rebate Data (KEYED)
-   * Used for API affiliates to query contract API rebate data within a certain time range
-   * Feature: Query up to 60 days of data
-   */
-getFuturesAffiliateRebateApi(
-    params: FuturesAffiliateRebateApiRequest,
-): Promise<APIResponse<FuturesAffiliateRebateApiResponse>>
-⋮----
-/**
-   * Deposit and withdrawal information of invited users (KEYED)
-   * Feature: Query up to 60 days; max 50 records per page (exchange update 2026-04-07).
-   */
-getFuturesAffiliateDepositWithdrawalList(
-    params: FuturesAffiliateDepositWithdrawalListRequest,
-): Promise<FuturesAffiliateDepositWithdrawalListResult>
-⋮----
-/**
-   * Simulated Claim (SIGNED)
-   * Add available funds to the futures account (Only available in the Simulated-Environment)
-   *
-   * Note: This endpoint is only available in the Simulated Trading environment.
-   * To use this endpoint, create a client instance with demoTrading: true
-   * Example:
-   *   const simulatedClient = new FuturesClientV2({
-   *     apiKey: 'your-api-key',
-   *     apiSecret: 'your-api-secret',
-   *     apiMemo: 'your-api-memo',
-   *     demoTrading: true
-   *   });
-   *
-   * Alternatively, you can manually set baseUrl: 'https://demo-api-cloud-v2.bitmart.com'
-   */
-submitFuturesSimulatedClaim(
-    params?: SubmitFuturesSimulatedClaimRequest,
-): Promise<APIResponse<FuturesSimulatedClaimResponse>>
-
-================
 File: README.md
 ================
 # Node.js & JavaScript SDK for BitMart REST API & WebSockets
@@ -5606,6 +5754,7 @@ File: README.md
 [![last commit](https://img.shields.io/github/last-commit/tiagosiebler/bitmart-api)][1]
 [![CodeFactor](https://www.codefactor.io/repository/github/tiagosiebler/bitmart-api/badge)](https://www.codefactor.io/repository/github/tiagosiebler/bitmart-api)
 [![Telegram](https://img.shields.io/badge/chat-on%20telegram-blue.svg)](https://t.me/nodetraders)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tiagosiebler/bitmart-api)
 
 <p align="center">
   <a href="https://www.npmjs.com/package/bitmart-api">
@@ -6113,7 +6262,7 @@ File: package.json
 ================
 {
   "name": "bitmart-api",
-  "version": "2.4.2",
+  "version": "2.4.4",
   "description": "Complete & robust Node.js SDK for BitMart's REST APIs and WebSockets, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",
@@ -6160,9 +6309,7 @@ File: package.json
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.3"
-  },
-  "optionalDependencies": {
+    "typescript": "^5.7.3",
     "webpack": "^5.0.0",
     "webpack-bundle-analyzer": "^5.1.1",
     "webpack-cli": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitmart-api",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitmart-api",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmart-api",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Complete & robust Node.js SDK for BitMart's REST APIs and WebSockets, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/src/FuturesClientV2.ts
+++ b/src/FuturesClientV2.ts
@@ -10,6 +10,7 @@ import {
   CancelFuturesOrderRequest,
   CancelFuturesPlanOrderRequest,
   CancelFuturesTrailOrderRequest,
+  CloseAllFuturesPositionsRequest,
   FuturesAccountHistoricOrderRequest,
   FuturesAccountHistoricTransactionRequest,
   FuturesAccountOpenOrdersRequest,
@@ -18,6 +19,7 @@ import {
   FuturesAccountTransfersRequest,
   FuturesAffiliateCustomerInfoRequest,
   FuturesAffiliateDepositWithdrawalListRequest,
+  FuturesAffiliateInviteCheckRequest,
   FuturesAffiliateRebateApiRequest,
   FuturesAffiliateRebateInviteUserRequest,
   FuturesAffiliateRebatesRequest,
@@ -31,6 +33,7 @@ import {
   FuturesSubWalletRequest,
   GetFuturesOrderRequest,
   SetFuturesLeverageRequest,
+  SubmitFuturesFundingAccountTransferRequest,
   SubmitFuturesOrderRequest,
   SubmitFuturesPlanOrderRequest,
   SubmitFuturesSimulatedClaimRequest,
@@ -59,6 +62,7 @@ import {
   FuturesAccountTransfer,
   FuturesAffiliateCustomerInfoResponse,
   FuturesAffiliateDepositWithdrawalListResult,
+  FuturesAffiliateInviteCheckResponse,
   FuturesAffiliateRebateApiResponse,
   FuturesAffiliateRebateInviteUserResponse,
   FuturesAffiliateRebateUserResponse,
@@ -357,6 +361,15 @@ export class FuturesClientV2 extends BaseRestClient {
     return this.postPrivate('contract/private/cancel-all-after', params);
   }
 
+  /**
+   * Feature: Market-close all or filtered futures positions (exchange update 2026-06-16).
+   */
+  closeAllFuturesPositions(
+    params: CloseAllFuturesPositionsRequest,
+  ): Promise<APIResponse<Record<string, never>>> {
+    return this.postPrivate('contract/private/close-all-position', params);
+  }
+
   submitFuturesPlanOrder(params: SubmitFuturesPlanOrderRequest): Promise<
     APIResponse<{
       order_id: number;
@@ -375,6 +388,15 @@ export class FuturesClientV2 extends BaseRestClient {
     params: SubmitFuturesTransferRequest,
   ): Promise<APIResponse<FuturesTransferSubmitResult>> {
     return this.postPrivate('account/v1/transfer-contract', params);
+  }
+
+  /**
+   * Feature: Funding account transfer between funding and futures accounts (exchange update 2026-06-29).
+   */
+  submitFuturesFundingAccountTransfer(
+    params: SubmitFuturesFundingAccountTransferRequest,
+  ): Promise<APIResponse<Record<string, never>>> {
+    return this.postPrivate('contract/private/account/v1/transfer', params);
   }
 
   setFuturesLeverage(
@@ -541,6 +563,15 @@ export class FuturesClientV2 extends BaseRestClient {
     params: FuturesAffiliateRebateUserRequest,
   ): Promise<APIResponse<FuturesAffiliateRebateUserResponse>> {
     return this.getPrivate('contract/private/affiliate/rebate-user', params);
+  }
+
+  /**
+   * Feature: Check if a user CID was invited by the affiliate (exchange update 2026-02-03).
+   */
+  getFuturesAffiliateInviteCheck(
+    params: FuturesAffiliateInviteCheckRequest,
+  ): Promise<APIResponse<FuturesAffiliateInviteCheckResponse>> {
+    return this.getPrivate('contract/private/affiliate/invite-check', params);
   }
 
   /**

--- a/src/RestClient.ts
+++ b/src/RestClient.ts
@@ -44,6 +44,7 @@ import {
   TransferFuturesAssetsRequest,
 } from './types/request/futures.types.js';
 import {
+  AccountBalancesV1Request,
   AccountSubTransfersV1Request,
   CancelAllSpotAlgoOrdersV4Request,
   CancelOrdersV3Request,
@@ -65,6 +66,7 @@ import {
   SpotOrderByClientOrderIdV4Request,
   SpotOrderByIdV4Request,
   SpotOrderTradeHistoryV4Request,
+  SubmitAccountTransferV1Request,
   SubmitMainTransferSubToSubV1Request,
   SubmitMarginTransferV1Request,
   SubmitSpotAlgoOrderV4Request,
@@ -144,6 +146,7 @@ import {
   SubmittedSpotBatchOrderResponseV2,
   SubTransferRow,
   SymbolMarginAccountDetailsV1,
+  UapiKeyAccountInfoResponse,
   WithdrawAddressListItem,
 } from './types/response/spot.types.js';
 
@@ -353,10 +356,28 @@ export class RestClient extends BaseRestClient {
    *
    **/
 
-  getAccountBalancesV1(params?: {
-    currency?: string;
-  }): Promise<APIResponse<{ wallet: AccountCurrencyBalanceV1[] }>> {
+  getAccountBalancesV1(
+    params?: AccountBalancesV1Request,
+  ): Promise<APIResponse<{ wallet: AccountCurrencyBalanceV1[] }>> {
     return this.getPrivate('account/v1/wallet', params);
+  }
+
+  /**
+   * Feature: Query account KYC and API key metadata (exchange update 2026-06-25).
+   * GET `uapi-key/v1/account/info`
+   */
+  getAccountInfoV1(): Promise<UapiKeyAccountInfoResponse> {
+    return this.getPrivate('uapi-key/v1/account/info');
+  }
+
+  /**
+   * Feature: Funding account transfer between funding and spot accounts (exchange update 2026-06-29).
+   * POST `account/v1/transfer`
+   */
+  submitAccountTransferV1(
+    params: SubmitAccountTransferV1Request,
+  ): Promise<APIResponse<Record<string, never>>> {
+    return this.postPrivate('account/v1/transfer', params);
   }
 
   getAccountCurrenciesV1(params?: {

--- a/src/types/request/futures.types.ts
+++ b/src/types/request/futures.types.ts
@@ -131,6 +131,20 @@ export interface SubmitFuturesTransferRequest {
   recvWindow?: number; // Trade time limit, allowed range (0,60000], default: 5000 milliseconds
 }
 
+/** POST `contract/private/account/v1/transfer` — funding account ↔ futures account transfer. */
+export interface SubmitFuturesFundingAccountTransferRequest {
+  currency?: string;
+  amount?: string;
+  type?: 'fund_to_contract' | 'contract_to_fund';
+}
+
+/** POST `contract/private/close-all-position` — market-close all or filtered futures positions. */
+export interface CloseAllFuturesPositionsRequest {
+  symbol?: string;
+  contractType: 1 | 2;
+  position_side?: 'long' | 'short';
+}
+
 export interface SetFuturesLeverageRequest {
   symbol: string; // Symbol of the contract(like BTCUSDT)
   leverage?: string; // Order leverage
@@ -262,6 +276,11 @@ export interface FuturesAffiliateDepositWithdrawalListRequest {
   cid: number;
   start_time: number;
   end_time: number;
+}
+
+/** GET `contract/private/affiliate/invite-check` — check if a user CID was invited by the affiliate. */
+export interface FuturesAffiliateInviteCheckRequest {
+  cid: number;
 }
 
 /** GET `contract/public/funding-rate-v2` — optional symbol; omit to query all pairs. */

--- a/src/types/request/spot.types.ts
+++ b/src/types/request/spot.types.ts
@@ -19,12 +19,25 @@ export interface SpotOrderBookDepthV1Request {
   size?: number;
 }
 
+export interface AccountBalancesV1Request {
+  currency?: string;
+  needUsdValuation?: boolean;
+  sourceAccount?: 'SPOT' | 'FUND';
+}
+
+export interface SubmitAccountTransferV1Request {
+  currency?: string;
+  amount?: string;
+  type?: 'spot_to_fund' | 'fund_to_spot';
+}
+
 export interface SubmitWithdrawalV1Request {
   currency: string;
   amount: string;
   destination: 'To Digital Address';
   address: string;
   address_memo?: string;
+  sourceAccount?: 'SPOT' | 'FUND';
 }
 
 export interface DepositWithdrawHistoryV2Request {

--- a/src/types/response/futures.types.ts
+++ b/src/types/response/futures.types.ts
@@ -425,3 +425,8 @@ export interface FuturesSimulatedClaimResponse {
   currency: string;
   amount: string;
 }
+
+/** GET `contract/private/affiliate/invite-check` */
+export interface FuturesAffiliateInviteCheckResponse {
+  isInviteUser: boolean;
+}

--- a/src/types/response/shared.types.ts
+++ b/src/types/response/shared.types.ts
@@ -16,4 +16,7 @@ export interface AccountCurrencyBalanceV1 {
   available: string;
   available_usd_valuation: string;
   frozen: string;
+  unAvailable?: string;
+  fundAvailable?: string;
+  fundFroze?: string;
 }

--- a/src/types/response/spot.types.ts
+++ b/src/types/response/spot.types.ts
@@ -412,3 +412,36 @@ export interface SpotBrokerRebateResult {
     [date: string]: SpotBrokerRebateRow[];
   };
 }
+
+/** GET `uapi-key/v1/account/info` — API key row in account info response. */
+export interface AccountApiKeyInfoV1 {
+  access_key_masked: string;
+  is_current: boolean;
+  permissions: string[];
+  ip_whitelist: string[];
+  api_key_label: string;
+  api_key_created_time: number;
+  api_key_expire_time: number;
+  api_key_status: 'active' | 'frozen' | 'expired';
+}
+
+/** GET `uapi-key/v1/account/info` — account KYC and API key metadata. */
+export interface AccountInfoV1 {
+  cid: string;
+  account_type: 'main' | 'sub';
+  parent_cid: string | null;
+  account_status: 'active' | 'frozen';
+  kyc_level: string;
+  register_time: number;
+  broker_id: string;
+  api_keys: AccountApiKeyInfoV1[];
+}
+
+/** Non-standard wrapper used by `uapi-key/v1/account/info`. */
+export interface UapiKeyAccountInfoResponse {
+  code: number;
+  msg: string;
+  data: AccountInfoV1;
+  errorData: unknown;
+  success: boolean;
+}


### PR DESCRIPTION
Release notes
Funding account support: transfer between funding ↔ spot, funding ↔ futures
Wallet balances now expose funding account fields (fundAvailable, fundFroze) and unavailable balance
Withdrawals can specify source account (spot vs funding)
New account info endpoint for KYC/API key metadata
Futures one-click close-all-positions
Affiliate invite-check endpoint
WebSocket types for book ticker and balance update account_type
